### PR TITLE
feat: configure lifecycle fixes + instance card config display

### DIFF
--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -75,6 +75,12 @@ func runDestroy(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("saving state: %w", err)
 		}
 
+		// Release any channel assigned to this instance so it becomes available again.
+		if assets, err := state.LoadAssets(); err == nil {
+			assets.ReleaseChannelByInstance(inst.Name)
+			_ = assets.SaveAssets()
+		}
+
 		if destroyPurge {
 			instanceDir := filepath.Join(dataDir, "data", inst.Name)
 			if err := os.RemoveAll(instanceDir); err != nil {

--- a/internal/container/configure.go
+++ b/internal/container/configure.go
@@ -22,6 +22,14 @@ type ConfigureParams struct {
 
 // Configure runs openclaw CLI commands inside the container to set up the instance.
 func Configure(cli *docker.Client, p ConfigureParams) error {
+	// Stop the gateway if it is already running (reconfigure case).
+	// This prevents config writes from triggering a hot-reload self-restart
+	// that spawns orphan child processes supervisor cannot track (port conflict),
+	// and avoids the gateway reloading with an incomplete intermediate config.
+	_ = dockerExecAs(cli, p.ContainerID, "root", []string{
+		"supervisorctl", "stop", "openclaw",
+	})
+
 	// Step 1: onboard with API key (runs as "node" — writes to ~node/.openclaw/)
 	apiKeyFlag := fmt.Sprintf("--%s-api-key", p.Provider)
 	if err := dockerExecAs(cli, p.ContainerID, "node", []string{
@@ -83,7 +91,15 @@ func Configure(cli *docker.Client, p ConfigureParams) error {
 			return fmt.Errorf("channels add: %w", err)
 		}
 
-		// Step 7: set DM and group policies to "open" so the bot responds
+		// Step 7: stop gateway before writing policy changes so they are
+		// applied offline — no hot-reload with incomplete intermediate config.
+		if err := dockerExecAs(cli, p.ContainerID, "root", []string{
+			"supervisorctl", "stop", "openclaw",
+		}); err != nil {
+			return fmt.Errorf("supervisorctl stop before policies: %w", err)
+		}
+
+		// Set DM and group policies to "open" so the bot responds
 		// without pairing. allowFrom must include "*" when policy is "open".
 		channelCfg := fmt.Sprintf("channels.%s", p.Channel)
 		policySteps := []struct{ path, value string }{
@@ -103,12 +119,11 @@ func Configure(cli *docker.Client, p ConfigureParams) error {
 			}
 		}
 
-		// Step 8: restart gateway to ensure all policy changes take effect.
-		// Hot reload may not pick up rapid successive config changes.
+		// Step 8: start gateway with the complete, final config.
 		if err := dockerExecAs(cli, p.ContainerID, "root", []string{
-			"supervisorctl", "restart", "openclaw",
+			"supervisorctl", "start", "openclaw",
 		}); err != nil {
-			return fmt.Errorf("supervisorctl restart: %w", err)
+			return fmt.Errorf("supervisorctl start after policies: %w", err)
 		}
 		if err := waitForGateway(cli, p.ContainerID, 30*time.Second); err != nil {
 			return fmt.Errorf("waiting for gateway restart: %w", err)

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -17,11 +17,13 @@ type Ports struct {
 }
 
 type Instance struct {
-	Name        string    `json:"name"`
-	ContainerID string    `json:"container_id"`
-	Status      string    `json:"status"`
-	Ports       Ports     `json:"ports"`
-	CreatedAt   time.Time `json:"created_at"`
+	Name           string    `json:"name"`
+	ContainerID    string    `json:"container_id"`
+	Status         string    `json:"status"`
+	Ports          Ports     `json:"ports"`
+	CreatedAt      time.Time `json:"created_at"`
+	ModelAssetID   string    `json:"model_asset_id,omitempty"`
+	ChannelAssetID string    `json:"channel_asset_id,omitempty"`
 }
 
 type Store struct {
@@ -121,6 +123,19 @@ func (s *Store) SetStatus(name, status string) {
 	for _, inst := range s.instances {
 		if inst.Name == name {
 			inst.Status = status
+			return
+		}
+	}
+}
+
+// SetConfig stores the asset IDs used to configure the named instance.
+func (s *Store) SetConfig(name, modelAssetID, channelAssetID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, inst := range s.instances {
+		if inst.Name == name {
+			inst.ModelAssetID = modelAssetID
+			inst.ChannelAssetID = channelAssetID
 			return
 		}
 	}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -17,21 +17,36 @@ import (
 
 // instanceResponse is the JSON representation of a single instance.
 type instanceResponse struct {
-	Name      string    `json:"name"`
-	Status    string    `json:"status"`
-	NoVNC     int       `json:"novnc_port"`
-	Gateway   int       `json:"gateway_port"`
-	CreatedAt time.Time `json:"created_at"`
+	Name           string    `json:"name"`
+	Status         string    `json:"status"`
+	NoVNC          int       `json:"novnc_port"`
+	Gateway        int       `json:"gateway_port"`
+	CreatedAt      time.Time `json:"created_at"`
+	ModelAssetID   string    `json:"model_asset_id,omitempty"`
+	ChannelAssetID string    `json:"channel_asset_id,omitempty"`
+	ModelName      string    `json:"model_name,omitempty"`
+	ChannelName    string    `json:"channel_name,omitempty"`
 }
 
-func instanceToResponse(inst state.Instance) instanceResponse {
-	return instanceResponse{
-		Name:      inst.Name,
-		Status:    inst.Status,
-		NoVNC:     inst.Ports.NoVNC,
-		Gateway:   inst.Ports.Gateway,
-		CreatedAt: inst.CreatedAt,
+func instanceToResponse(inst state.Instance, assets *state.AssetStore) instanceResponse {
+	resp := instanceResponse{
+		Name:           inst.Name,
+		Status:         inst.Status,
+		NoVNC:          inst.Ports.NoVNC,
+		Gateway:        inst.Ports.Gateway,
+		CreatedAt:      inst.CreatedAt,
+		ModelAssetID:   inst.ModelAssetID,
+		ChannelAssetID: inst.ChannelAssetID,
 	}
+	if assets != nil {
+		if m := assets.GetModel(inst.ModelAssetID); m != nil {
+			resp.ModelName = m.Name
+		}
+		if c := assets.GetChannel(inst.ChannelAssetID); c != nil {
+			resp.ChannelName = c.Name
+		}
+	}
+	return resp
 }
 
 // handleListInstances returns all instances with live status from Docker.
@@ -42,13 +57,15 @@ func (s *Server) handleListInstances(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	assets, _ := s.loadAssets()
+
 	instances := store.Snapshot()
 	results := make([]instanceResponse, 0, len(instances))
 	for _, inst := range instances {
 		status, _, _ := container.Status(s.docker, inst.ContainerID)
 		store.SetStatus(inst.Name, status)
 		inst.Status = status
-		results = append(results, instanceToResponse(inst))
+		results = append(results, instanceToResponse(inst, assets))
 	}
 
 	_ = store.Save()
@@ -166,7 +183,7 @@ func (s *Server) handleCreateInstances(w http.ResponseWriter, r *http.Request) {
 		}
 
 		s.events.Publish(Event{Type: EventCreated, Name: name})
-		created = append(created, instanceToResponse(*inst))
+		created = append(created, instanceToResponse(*inst, nil))
 	}
 
 	writeJSON(w, http.StatusCreated, map[string]any{"data": created})
@@ -195,7 +212,7 @@ func (s *Server) handleStartInstance(w http.ResponseWriter, r *http.Request) {
 
 	inst.Status = "running"
 	s.events.Publish(Event{Type: EventStarted, Name: name})
-	writeJSON(w, http.StatusOK, map[string]any{"data": instanceToResponse(*inst)})
+	writeJSON(w, http.StatusOK, map[string]any{"data": instanceToResponse(*inst, nil)})
 }
 
 // handleStopInstance stops a running instance.
@@ -221,7 +238,7 @@ func (s *Server) handleStopInstance(w http.ResponseWriter, r *http.Request) {
 
 	inst.Status = "stopped"
 	s.events.Publish(Event{Type: EventStopped, Name: name})
-	writeJSON(w, http.StatusOK, map[string]any{"data": instanceToResponse(*inst)})
+	writeJSON(w, http.StatusOK, map[string]any{"data": instanceToResponse(*inst, nil)})
 }
 
 // handleDestroyInstance removes an instance and optionally purges data.
@@ -247,6 +264,12 @@ func (s *Server) handleDestroyInstance(w http.ResponseWriter, r *http.Request) {
 
 	store.Remove(name)
 	_ = store.Save()
+
+	// Release any channel assigned to this instance so it becomes available again.
+	if assets, err := s.loadAssets(); err == nil {
+		assets.ReleaseChannelByInstance(name)
+		_ = assets.SaveAssets()
+	}
 
 	if purge {
 		dataDir, _ := config.DataDir()

--- a/internal/web/handlers_configure.go
+++ b/internal/web/handlers_configure.go
@@ -121,6 +121,10 @@ func (s *Server) handleConfigureInstance(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Persist which asset IDs were used so the card and dialog can show them.
+	store.SetConfig(name, req.ModelAssetID, req.ChannelAssetID)
+	_ = store.Save()
+
 	writeJSON(w, http.StatusOK, map[string]any{
 		"data": map[string]string{
 			"status":  "configured",

--- a/internal/web/static/css/style.css
+++ b/internal/web/static/css/style.css
@@ -317,6 +317,41 @@ body {
   font-size: 0.78rem;
 }
 
+/* Config info */
+.card-config {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  margin-bottom: 14px;
+  padding: 8px 10px;
+  background: var(--surface-alt);
+  border-radius: 6px;
+}
+
+.config-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+}
+
+.config-label {
+  color: var(--text-dim);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.config-value {
+  color: var(--text);
+  font-size: 0.8rem;
+}
+
+.config-unconfigured {
+  color: var(--text-dim);
+  font-style: italic;
+}
+
 /* Stats bars */
 .card-stats { margin-bottom: 14px; }
 

--- a/internal/web/static/js/app.js
+++ b/internal/web/static/js/app.js
@@ -220,6 +220,7 @@ function App() {
     ${configureName && html`
       <${ConfigureDialog}
         instanceName=${configureName}
+        currentModelAssetId=${(instances.find(i => i.name === configureName) || {}).model_asset_id || ''}
         onClose=${() => setConfigureName(null)}
         onConfigure=${onConfigure}
       />

--- a/internal/web/static/js/components/configure-dialog.js
+++ b/internal/web/static/js/components/configure-dialog.js
@@ -2,11 +2,11 @@ import { html, useState, useEffect } from '../lib.js';
 import { useLang } from '../i18n.js';
 import { api } from '../api.js';
 
-export function ConfigureDialog({ instanceName, onClose, onConfigure }) {
+export function ConfigureDialog({ instanceName, currentModelAssetId, onClose, onConfigure }) {
   const { t } = useLang();
   const [models, setModels] = useState([]);
   const [channels, setChannels] = useState([]);
-  const [selectedModel, setSelectedModel] = useState('');
+  const [selectedModel, setSelectedModel] = useState(currentModelAssetId || '');
   const [selectedChannel, setSelectedChannel] = useState('');
   const [configuring, setConfiguring] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -18,6 +18,9 @@ export function ConfigureDialog({ instanceName, onClose, onConfigure }) {
     ]).then(([modelData, channelData]) => {
       setModels(modelData || []);
       setChannels(channelData || []);
+
+      // Pre-select model assigned to this instance
+      if (currentModelAssetId) setSelectedModel(currentModelAssetId);
 
       // Pre-select channel assigned to this instance
       const assignedCh = (channelData || []).find(c => c.used_by === instanceName);

--- a/internal/web/static/js/components/instance-card.js
+++ b/internal/web/static/js/components/instance-card.js
@@ -32,6 +32,26 @@ export function InstanceCard({ instance, stats, pending, onStart, onStop, onDest
         </div>
       </div>
 
+      <div class="card-config">
+        ${instance.model_name ? html`
+          <div class="config-item">
+            <span class="config-label">Model</span>
+            <span class="config-value">${instance.model_name}</span>
+          </div>
+        ` : ''}
+        ${instance.channel_name ? html`
+          <div class="config-item">
+            <span class="config-label">Channel</span>
+            <span class="config-value">${instance.channel_name}</span>
+          </div>
+        ` : ''}
+        ${!instance.model_name && !instance.channel_name ? html`
+          <div class="config-item">
+            <span class="config-value config-unconfigured">${t('card.unconfigured')}</span>
+          </div>
+        ` : ''}
+      </div>
+
       ${isRunning && stats && html`
         <div class="card-stats">
           <div class="stat-row">

--- a/internal/web/static/js/i18n.js
+++ b/internal/web/static/js/i18n.js
@@ -23,6 +23,7 @@ const messages = {
     'card.stop':             '⏹ Stop',
     'card.start':            '▶ Start',
     'card.destroy':          '🗑 Destroy',
+    'card.unconfigured':     'Not configured',
 
     'create.title':          'Create Instances',
     'create.label':          'Number of instances',
@@ -145,6 +146,7 @@ const messages = {
     'card.stop':             '⏹ 停止',
     'card.start':            '▶ 启动',
     'card.destroy':          '🗑 销毁',
+    'card.unconfigured':     '未配置',
 
     'create.title':          '创建实例',
     'create.label':          '实例数量',


### PR DESCRIPTION
## Summary
- **Fix: gateway port conflict on reconfigure** — stop gateway before config writes to prevent orphan child processes from hot-reload self-restart
- **Fix: channels not released on destroy** — both CLI and Dashboard now call `ReleaseChannelByInstance` when destroying instances, so channels become available for reassignment
- **Feature: instance cards show config info** — cards display assigned Model and Channel names (or "Not configured")
- **Feature: configure dialog pre-selects current config** — reopening Configure on an already-configured instance pre-selects the current Model and Channel

## Test plan
- [ ] Destroy an instance with an assigned channel, verify the channel becomes available for other instances
- [ ] Configure an instance, verify the card shows Model and Channel names
- [ ] Re-open Configure dialog on a configured instance, verify Model and Channel are pre-selected
- [ ] Reconfigure an instance (change model/channel), verify no port conflict or gateway crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)