### PR TITLE
docs: add wiki documentation section and link READMEs to wiki

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,3 +62,56 @@ All design decisions, project structure, and code implementation must follow bes
 ### Simplicity & Minimal Surface
 - Don't add abstractions, flags, or config options for hypothetical future needs. Solve the current problem directly.
 - Prefer calling existing CLI tools (`docker exec` + `openclaw` CLI) over writing config files directly — this keeps the integration resilient to upstream format changes.
+
+## Wiki Documentation
+
+The project wiki lives in a separate repo (`git@github.com:weiyong1024/ClawSandbox.wiki.git`) and is browsable at `https://github.com/weiyong1024/ClawSandbox/wiki`. It is the primary documentation hub beyond the README.
+
+### Wiki structure
+
+| File | Purpose |
+|------|---------|
+| `_Sidebar.md` | Navigation sidebar shown on every page |
+| `_Footer.md` | Footer with repo link |
+| `Home.md` | Landing page — value prop, quickstart roadmap, page index |
+| `Getting-Started.md` | Prerequisites, install, first instance end-to-end |
+| `Dashboard-Guide.md` | Sidebar navigation, asset management, fleet management, image management |
+| `CLI-Reference.md` | All CLI commands with descriptions and examples |
+| `FAQ.md` | Common issues grouped by install / config / resource / operations |
+| `Provider-{Anthropic,OpenAI,Google,DeepSeek}.md` | LLM provider guides (one per provider) |
+| `Channel-{Telegram,Discord,Slack,Lark}.md` | Messaging channel guides (one per channel) |
+
+### Content conventions
+
+- **Provider pages** follow a consistent template: Overview → Get API Key (step-by-step) → Add in Dashboard → Assign to Instance → Pricing Notes → Troubleshooting.
+- **Channel pages** follow: Overview → Create Bot (step-by-step) → Add in Dashboard → Assign to Instance → Test → Notes → Troubleshooting.
+- Key facts to keep consistent across pages:
+  - **Models are shared** — multiple instances can use the same model config simultaneously.
+  - **Channels are exclusive** — each channel can only be assigned to one instance at a time.
+  - **Validation required** — must click "Test" and see validation pass before saving.
+  - **Lark is different** — uses App ID + App Secret, not a single token.
+  - **Auto-configuration** — ClawSandbox sets DM/group policies to "open" and allows all senders automatically.
+- Preset models are defined in `internal/web/static/js/components/model-asset-dialog.js` (`MODEL_PRESETS`). When models change there, update the wiki provider pages and `Dashboard-Guide.md`.
+- Validation logic is in `internal/web/validate.go`. If validation endpoints change, update the corresponding channel/provider troubleshooting sections.
+
+### When to update the wiki
+
+**You must update the wiki whenever a code change affects user-facing behavior.** Specifically:
+
+- **New or removed CLI command** → update `CLI-Reference.md`, and `Getting-Started.md` / `FAQ.md` if relevant.
+- **New LLM provider** → create `Provider-<Name>.md` using the existing template, add to `_Sidebar.md`, update `Home.md` page index and `Dashboard-Guide.md` preset table.
+- **New messaging channel** → create `Channel-<Name>.md` using the existing template, add to `_Sidebar.md`, update `Home.md` page index.
+- **Dashboard UI changes** (new sections, renamed labels, changed workflows) → update `Dashboard-Guide.md` and `Getting-Started.md`.
+- **Model preset changes** → update `Dashboard-Guide.md` preset table and the relevant `Provider-*.md` page.
+- **README wiki links** — both `README.md` and `README.zh-CN.md` have a "Documentation" section linking to wiki pages. Update these links if wiki page names change.
+
+### How to edit the wiki
+
+```bash
+git clone git@github.com:weiyong1024/ClawSandbox.wiki.git /tmp/ClawSandbox.wiki
+cd /tmp/ClawSandbox.wiki
+# Edit files...
+git add . && git commit -m "describe the change" && git push
+```
+
+The wiki repo uses `master` as its default branch.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ The Dashboard provides:
 
 ![Instance Desktop](docs/images/instance-desktop.jpeg)
 
+## Documentation
+
+See the **[Wiki](https://github.com/weiyong1024/ClawSandbox/wiki)** for full documentation, including:
+- [Getting Started](https://github.com/weiyong1024/ClawSandbox/wiki/Getting-Started) — prerequisites, install, first instance
+- [Dashboard Guide](https://github.com/weiyong1024/ClawSandbox/wiki/Dashboard-Guide) — sidebar navigation, asset management, fleet management
+- LLM Provider guides — [Anthropic](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-Anthropic) | [OpenAI](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-OpenAI) | [Google](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-Google) | [DeepSeek](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-DeepSeek)
+- Channel guides — [Telegram](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Telegram) | [Discord](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Discord) | [Slack](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Slack) | [Lark](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Lark)
+- [CLI Reference](https://github.com/weiyong1024/ClawSandbox/wiki/CLI-Reference) | [FAQ](https://github.com/weiyong1024/ClawSandbox/wiki/FAQ)
+
 ## CLI Reference
 
 Every command supports `--help` for detailed usage and examples:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,6 +79,15 @@ clawsandbox dashboard serve
 
 ![实例桌面](docs/images/instance-desktop.jpeg)
 
+## 文档
+
+完整文档请参阅 **[Wiki](https://github.com/weiyong1024/ClawSandbox/wiki)**，包括：
+- [快速开始](https://github.com/weiyong1024/ClawSandbox/wiki/Getting-Started) — 前置要求、安装、第一个实例
+- [仪表盘指南](https://github.com/weiyong1024/ClawSandbox/wiki/Dashboard-Guide) — 侧边栏导航、资产管理、实例管理
+- LLM 提供商指南 — [Anthropic](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-Anthropic) | [OpenAI](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-OpenAI) | [Google](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-Google) | [DeepSeek](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-DeepSeek)
+- 频道指南 — [Telegram](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Telegram) | [Discord](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Discord) | [Slack](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Slack) | [Lark](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Lark)
+- [CLI 参考](https://github.com/weiyong1024/ClawSandbox/wiki/CLI-Reference) | [常见问题](https://github.com/weiyong1024/ClawSandbox/wiki/FAQ)
+
 ## CLI 命令
 
 任何命令都可以加 `--help` 查看详细用法和示例：


### PR DESCRIPTION
## Summary

- Add **Wiki Documentation** section to `CLAUDE.md` — wiki structure, content conventions, update triggers, and editing instructions so future contributors (and their Claude Code sessions) keep the wiki in sync with code changes
- Add **Documentation** section to both `README.md` and `README.zh-CN.md` linking to all wiki pages (providers, channels, dashboard guide, CLI reference, FAQ)

## Test plan

- [x] Verify wiki links in READMEs resolve correctly: https://github.com/weiyong1024/ClawSandbox/wiki
- [x] Review CLAUDE.md wiki maintenance instructions for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)