### PR TITLE
feat: bot-to-bot communication and instance reset

### DIFF
--- a/internal/container/configure.go
+++ b/internal/container/configure.go
@@ -18,6 +18,7 @@ type ConfigureParams struct {
 	Model        string // e.g. "claude-sonnet-4-6"
 	Channel      string // e.g. "telegram"
 	ChannelToken string // bot token
+	BotName      string // bot display name for text @mention detection
 }
 
 // Configure runs openclaw CLI commands inside the container to set up the instance.
@@ -99,14 +100,29 @@ func Configure(cli *docker.Client, p ConfigureParams) error {
 			return fmt.Errorf("supervisorctl stop before policies: %w", err)
 		}
 
-		// Set DM and group policies to "open" so the bot responds
-		// without pairing. allowFrom must include "*" when policy is "open".
+		// Set policies to "open" so the bot responds without pairing.
+		// allowFrom must include "*" when policy is "open".
+		// Note: groupAllowFrom is only supported by some channels (e.g. Telegram)
+		// but not others (e.g. Discord), so we set it only when applicable.
 		channelCfg := fmt.Sprintf("channels.%s", p.Channel)
 		policySteps := []struct{ path, value string }{
 			{channelCfg + ".allowFrom", `["*"]`},
 			{channelCfg + ".dmPolicy", "open"},
-			{channelCfg + ".groupAllowFrom", `["*"]`},
 			{channelCfg + ".groupPolicy", "open"},
+		}
+		if p.Channel == "telegram" {
+			policySteps = append(policySteps, struct{ path, value string }{
+				channelCfg + ".groupAllowFrom", `["*"]`,
+			})
+		}
+		// Step 7b: enable bot-to-bot communication for channels that support it.
+		// "mentions" mode: only process bot messages that @mention this bot,
+		// which enables directed bot-to-bot conversation while preventing
+		// infinite reply loops from unmentioned bot chatter.
+		if p.Channel == "discord" || p.Channel == "slack" {
+			policySteps = append(policySteps, struct{ path, value string }{
+				channelCfg + ".allowBots", "mentions",
+			})
 		}
 		for _, s := range policySteps {
 			args := []string{"openclaw", "config", "set", s.path, s.value}
@@ -119,7 +135,21 @@ func Configure(cli *docker.Client, p ConfigureParams) error {
 			}
 		}
 
-		// Step 8: start gateway with the complete, final config.
+		// Step 8: set agent identity name for text @mention detection.
+		// This enables bot-to-bot communication: when Bot-A sends "@Bot-B",
+		// OpenClaw on Bot-B matches it via mentionPatterns regex derived
+		// from the identity name, even though it's not a native platform mention.
+		// Identity lives under agents.list[].identity, not agents.defaults.
+		if p.BotName != "" {
+			agentsList := fmt.Sprintf(`[{"id":"main","identity":{"name":"%s"}}]`, p.BotName)
+			if err := dockerExecAs(cli, p.ContainerID, "node", []string{
+				"openclaw", "config", "set", "agents.list", agentsList, "--strict-json",
+			}); err != nil {
+				return fmt.Errorf("config set agents.list: %w", err)
+			}
+		}
+
+		// Step 9: start gateway with the complete, final config.
 		if err := dockerExecAs(cli, p.ContainerID, "root", []string{
 			"supervisorctl", "start", "openclaw",
 		}); err != nil {
@@ -222,6 +252,11 @@ func ConfigStatus(cli *docker.Client, containerID string) (*ConfigInfo, error) {
 	}
 
 	return info, nil
+}
+
+// ExecAs runs a command inside a container as the specified user (public wrapper).
+func ExecAs(cli *docker.Client, containerID, user string, cmd []string) error {
+	return dockerExecAs(cli, containerID, user, cmd)
 }
 
 // dockerExecAs runs a command inside a container as the specified user.

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -244,7 +244,9 @@ func (s *Server) handleStopInstance(w http.ResponseWriter, r *http.Request) {
 // handleDestroyInstance removes an instance and optionally purges data.
 func (s *Server) handleDestroyInstance(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
-	purge := r.URL.Query().Get("purge") == "true"
+	// Default: always purge data so recreated instances start fresh.
+	// Pass ?purge=false to explicitly preserve data.
+	purge := r.URL.Query().Get("purge") != "false"
 
 	store, err := s.loadStore()
 	if err != nil {
@@ -278,6 +280,75 @@ func (s *Server) handleDestroyInstance(w http.ResponseWriter, r *http.Request) {
 
 	s.events.Publish(Event{Type: EventDestroyed, Name: name})
 	writeJSON(w, http.StatusOK, map[string]any{"data": map[string]string{"name": name, "status": "destroyed"}})
+}
+
+// handleResetInstance purges the persisted OpenClaw config so the instance
+// can be reconfigured from scratch without destroying the container.
+func (s *Server) handleResetInstance(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+
+	store, err := s.loadStore()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	inst := store.Get(name)
+	if inst == nil {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("instance %s not found", name))
+		return
+	}
+
+	// Stop openclaw gateway if running.
+	status, _, _ := container.Status(s.docker, inst.ContainerID)
+	if status == "running" {
+		_ = container.ExecAs(s.docker, inst.ContainerID, "root", []string{
+			"supervisorctl", "stop", "openclaw",
+		})
+	}
+
+	// Remove only OpenClaw config and auth data, preserving Node.js V8 caches
+	// and other runtime state to avoid slow JIT recompilation on next configure.
+	dataDir, err := config.DataDir()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	instanceDataDir := filepath.Join(dataDir, "data", name, "openclaw")
+	for _, sub := range []string{
+		"openclaw.json",
+		"agents",
+		"sessions",
+		"channels",
+	} {
+		_ = os.RemoveAll(filepath.Join(instanceDataDir, sub))
+	}
+
+	// Release any channel assets assigned to this instance.
+	assets, err := s.loadAssets()
+	if err == nil {
+		assets.ReleaseChannelByInstance(name)
+		_ = assets.SaveAssets()
+	}
+
+	// Restart the container to clear Node.js runtime degradation that causes
+	// openclaw CLI commands to hang in long-running containers.
+	if status == "running" {
+		if err := container.Stop(s.docker, inst.ContainerID); err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("restarting %s: %v", name, err))
+			return
+		}
+		if err := container.Start(s.docker, inst.ContainerID); err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("restarting %s: %v", name, err))
+			return
+		}
+		store.SetStatus(name, "running")
+	}
+	_ = store.Save()
+
+	s.events.Publish(Event{Type: EventStopped, Name: name})
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": map[string]string{"name": name, "status": "reset"},
+	})
 }
 
 // handleInstanceLogs returns the last 100 lines of container logs.

--- a/internal/web/handlers_configure.go
+++ b/internal/web/handlers_configure.go
@@ -109,6 +109,12 @@ func (s *Server) handleConfigureInstance(w http.ResponseWriter, r *http.Request)
 		_ = store.Save()
 	}
 
+	// Resolve bot display name from the channel platform for text @mention detection.
+	var botName string
+	if req.Channel != "" && req.ChannelToken != "" {
+		botName = resolveBotName(req.Channel, req.ChannelToken)
+	}
+
 	if err := container.Configure(s.docker, container.ConfigureParams{
 		ContainerID:  inst.ContainerID,
 		Provider:     req.Provider,
@@ -116,6 +122,7 @@ func (s *Server) handleConfigureInstance(w http.ResponseWriter, r *http.Request)
 		Model:        req.Model,
 		Channel:      req.Channel,
 		ChannelToken: req.ChannelToken,
+		BotName:      botName,
 	}); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("configure failed: %v", err))
 		return

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -13,6 +13,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/instances/{name}/start", s.handleStartInstance)
 	mux.HandleFunc("POST /api/v1/instances/{name}/stop", s.handleStopInstance)
 	mux.HandleFunc("DELETE /api/v1/instances/{name}", s.handleDestroyInstance)
+	mux.HandleFunc("POST /api/v1/instances/{name}/reset", s.handleResetInstance)
 	mux.HandleFunc("GET /api/v1/instances/{name}/logs", s.handleInstanceLogs)
 	mux.HandleFunc("POST /api/v1/instances/{name}/configure", s.handleConfigureInstance)
 	mux.HandleFunc("GET /api/v1/instances/{name}/configure/status", s.handleConfigureStatus)

--- a/internal/web/static/js/api.js
+++ b/internal/web/static/js/api.js
@@ -23,7 +23,8 @@ export const api = {
   createInstances:(count)       => request('POST',   '/instances', { count }),
   startInstance:  (name)        => request('POST',   `/instances/${encodeURIComponent(name)}/start`),
   stopInstance:   (name)        => request('POST',   `/instances/${encodeURIComponent(name)}/stop`),
-  destroyInstance:(name, purge) => request('DELETE',  `/instances/${encodeURIComponent(name)}${purge ? '?purge=true' : ''}`),
+  destroyInstance:(name)        => request('DELETE',  `/instances/${encodeURIComponent(name)}`),
+  resetInstance:  (name)        => request('POST',   `/instances/${encodeURIComponent(name)}/reset`),
   configureInstance: (name, config) => request('POST', `/instances/${encodeURIComponent(name)}/configure`, config),
   getConfigStatus:   (name)        => request('GET',  `/instances/${encodeURIComponent(name)}/configure/status`),
 

--- a/internal/web/static/js/app.js
+++ b/internal/web/static/js/app.js
@@ -135,6 +135,18 @@ function App() {
     })();
   };
 
+  const onReset = async (name) => {
+    if (!confirm(t('confirm.reset', name))) return;
+    await withPending(name, 'resetting', async () => {
+      try {
+        await api.resetInstance(name);
+        addToast(t('toast.reset', name), 'success');
+      } catch (err) {
+        addToast(err.message, 'error');
+      }
+    })();
+  };
+
   const onConfigure = async (name, config) => {
     try {
       await api.configureInstance(name, config);
@@ -200,6 +212,7 @@ function App() {
           onDestroy=${onDestroy}
           onDesktop=${navigate}
           onConfigure=${(name) => setConfigureName(name)}
+          onReset=${onReset}
           onCreateClick=${() => setShowCreate(true)}
         />
       `;

--- a/internal/web/static/js/components/configure-dialog.js
+++ b/internal/web/static/js/components/configure-dialog.js
@@ -106,7 +106,8 @@ export function ConfigureDialog({ instanceName, currentModelAssetId, onClose, on
               </div>
             </div>
             <div class="dialog-footer">
-              <button type="button" class="btn btn-ghost" onClick=${onClose}>${t('configure.cancel')}</button>
+              ${configuring && html`<span class="form-hint" style="margin-right:auto">${t('configure.timeHint')}</span>`}
+              <button type="button" class="btn btn-ghost" onClick=${onClose} disabled=${configuring}>${t('configure.cancel')}</button>
               <button type="submit" class="btn btn-primary" disabled=${configuring || !selectedModel}>
                 ${configuring ? t('configure.configuring') : t('configure.submit')}
               </button>

--- a/internal/web/static/js/components/dashboard.js
+++ b/internal/web/static/js/components/dashboard.js
@@ -13,7 +13,7 @@ function SkeletonCard() {
   `;
 }
 
-export function Dashboard({ instances, stats, loading, pending, onStart, onStop, onDestroy, onDesktop, onConfigure, onCreateClick }) {
+export function Dashboard({ instances, stats, loading, pending, onStart, onStop, onDestroy, onDesktop, onConfigure, onReset, onCreateClick }) {
   const { t } = useLang();
 
   if (loading) {
@@ -54,6 +54,7 @@ export function Dashboard({ instances, stats, loading, pending, onStart, onStop,
               onDestroy=${() => onDestroy(inst.name)}
               onDesktop=${() => onDesktop(inst.name)}
               onConfigure=${() => onConfigure(inst.name)}
+              onReset=${() => onReset(inst.name)}
             />
           `)}
         </div>

--- a/internal/web/static/js/components/instance-card.js
+++ b/internal/web/static/js/components/instance-card.js
@@ -2,7 +2,7 @@ import { html } from '../lib.js';
 import { useLang } from '../i18n.js';
 import { formatBytes } from '../utils.js';
 
-export function InstanceCard({ instance, stats, pending, onStart, onStop, onDestroy, onDesktop, onConfigure }) {
+export function InstanceCard({ instance, stats, pending, onStart, onStop, onDestroy, onDesktop, onConfigure, onReset }) {
   const { t } = useLang();
   const isRunning = instance.status === 'running';
   const cpu = stats?.cpu_percent ?? 0;
@@ -76,6 +76,9 @@ export function InstanceCard({ instance, stats, pending, onStart, onStop, onDest
           <button class="btn btn-sm btn-desktop" onClick=${onDesktop} disabled=${busy}>${t('card.desktop')}</button>
           <button class="btn btn-sm btn-configure" onClick=${onConfigure} disabled=${busy}>
             ${pending === 'configuring' ? t('action.configuring') : t('card.configure')}
+          </button>
+          <button class="btn btn-sm btn-ghost" onClick=${onReset} disabled=${busy}>
+            ${pending === 'resetting' ? t('action.resetting') : t('card.reset')}
           </button>
           <button class="btn btn-sm btn-warning" onClick=${onStop} disabled=${busy}>
             ${pending === 'stopping' ? t('action.stopping') : t('card.stop')}

--- a/internal/web/static/js/i18n.js
+++ b/internal/web/static/js/i18n.js
@@ -53,8 +53,12 @@ const messages = {
     'action.stopping':       'Stopping...',
     'action.destroying':     'Destroying...',
     'action.configuring':    'Configuring...',
+    'action.resetting':      'Resetting...',
 
     'card.configure':        'Configure',
+    'card.reset':            'Reset',
+    'toast.reset':           (name) => `${name} reset successfully`,
+    'confirm.reset':         (name) => `Reset ${name}? This clears all configuration and channel assignments.`,
 
     'configure.title':       'Configure Instance',
     'configure.provider':    'Provider',
@@ -73,6 +77,7 @@ const messages = {
     'configure.channelConfig': 'Channel Config (optional)',
     'configure.noModels':    'No model configs available. Add one in Assets → Model Config.',
     'configure.noChannel':   'None',
+    'configure.timeHint':    'This may take 1–2 minutes. Please do not close the dialog.',
     'configure.unavailableModels': (n) => `${n} more config(s) used by other instances`,
 
     // Assets
@@ -176,8 +181,12 @@ const messages = {
     'action.stopping':       '停止中...',
     'action.destroying':     '销毁中...',
     'action.configuring':    '配置中...',
+    'action.resetting':      '重置中...',
 
     'card.configure':        '配置',
+    'card.reset':            '重置',
+    'toast.reset':           (name) => `${name} 已重置`,
+    'confirm.reset':         (name) => `确定重置 ${name}？这将清除所有配置和 Channel 绑定。`,
 
     'configure.title':       '配置实例',
     'configure.provider':    '提供商',
@@ -196,6 +205,7 @@ const messages = {
     'configure.channelConfig': 'Channel 配置（可选）',
     'configure.noModels':    '暂无可用的 Model 配置。请先在「资产管理 → Model 配置」中添加。',
     'configure.noChannel':   '无',
+    'configure.timeHint':    '配置大约需要 1–2 分钟，请勿关闭此对话框。',
     'configure.unavailableModels': (n) => `另有 ${n} 个配置已被其他实例使用`,
 
     // Assets

--- a/internal/web/validate.go
+++ b/internal/web/validate.go
@@ -129,6 +129,65 @@ func validateDiscord(token string) error {
 	return doValidationRequest(req, "Discord")
 }
 
+// resolveBotName calls the channel platform API to get the bot's display name.
+// Returns empty string on failure (non-critical — text @mention detection
+// simply won't work, but the bot still functions normally).
+func resolveBotName(channel, token string) string {
+	switch channel {
+	case "discord":
+		return resolveDiscordBotName(token)
+	case "slack":
+		return resolveSlackBotName(token)
+	default:
+		return ""
+	}
+}
+
+func resolveDiscordBotName(token string) string {
+	req, err := http.NewRequest("GET", "https://discord.com/api/v10/users/@me", nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Authorization", "Bot "+token)
+	resp, err := httpClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	defer resp.Body.Close()
+	var result struct {
+		GlobalName string `json:"global_name"`
+		Username   string `json:"username"`
+	}
+	if json.NewDecoder(resp.Body).Decode(&result) != nil {
+		return ""
+	}
+	if result.GlobalName != "" {
+		return result.GlobalName
+	}
+	return result.Username
+}
+
+func resolveSlackBotName(token string) string {
+	req, err := http.NewRequest("POST", "https://slack.com/api/auth.test", nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := httpClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	defer resp.Body.Close()
+	var result struct {
+		OK   bool   `json:"ok"`
+		User string `json:"user"`
+	}
+	if json.NewDecoder(resp.Body).Decode(&result) != nil || !result.OK {
+		return ""
+	}
+	return result.User
+}
+
 func validateSlack(token string) error {
 	req, err := http.NewRequest("POST", "https://slack.com/api/auth.test", nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- **Bot-to-bot communication**: Configure `allowBots: "mentions"` for Discord/Slack channels and set `agents.list[].identity.name` via platform API (`/users/@me`) so bots detect text @mentions (e.g. `@Engineer`) from other bots using OpenClaw's `deriveMentionPatterns` regex
- **Instance reset**: New `POST /instances/{name}/reset` endpoint — stops gateway, purges config/auth/sessions/channels, releases channel assets, and restarts the container to clear Node.js runtime degradation in long-running containers
- **Destroy fixes**: Always purge data on destroy (default `purge=true`), release channel assets so they become available for new instances
- **Configure UX**: Show time estimate hint during configuration, disable Cancel button while configuring to prevent premature close

## Changed files
- `internal/container/configure.go` — `BotName` param, channel-specific policies (`groupAllowFrom` Telegram-only, `allowBots` Discord/Slack), identity name via `agents.list`
- `internal/web/handlers.go` — Reset handler with container restart, destroy purge default + channel release
- `internal/web/handlers_configure.go` — Resolve bot display name from platform API
- `internal/web/validate.go` — `resolveBotName()`, `resolveDiscordBotName()`, `resolveSlackBotName()`
- `internal/web/routes.go` — Reset route
- `internal/web/static/js/` — Reset button, API binding, i18n (EN/ZH), configure dialog UX

## Test plan
- [x] Reset instance via `POST /instances/claw-1/reset` — returns `{"status":"reset"}`, container restarts
- [x] Configure after reset completes without hanging
- [x] `agents.list` identity name set correctly (`openclaw config get agents.list`)
- [x] `allowBots: "mentions"` set for Discord channels
- [x] Channel assets released on destroy and reset (`used_by` cleared)
- [x] Destroy always purges data directory by default
- [x] Bots respond to name mentions in Discord group chat (text `@BotName` without native Discord mention)
- [x] Bots perceive other bots' messages in group

🤖 Generated with [Claude Code](https://claude.com/claude-code)