### PR TITLE
fix: enable autorestart for openclaw gateway

### DIFF
--- a/internal/assets/docker/supervisord.conf
+++ b/internal/assets/docker/supervisord.conf
@@ -46,13 +46,16 @@ stdout_logfile=/tmp/novnc.log
 stderr_logfile=/tmp/novnc.err.log
 
 ; ── OpenClaw Gateway ──────────────────────────────────────────────────────────
-; autostart=false: user must run 'openclaw onboard' first via the desktop terminal.
-; After onboarding, start manually with: supervisorctl start openclaw
+; autostart=false: the gateway cannot start until 'openclaw onboard' has been run.
+; After onboarding, ClawSandbox starts it via: supervisorctl start openclaw
+; autorestart=true: if the gateway crashes after successful startup, supervisord
+; will restart it automatically. This does NOT conflict with supervisorctl stop —
+; manually stopped processes stay stopped regardless of autorestart setting.
 [program:openclaw]
 command=openclaw gateway --port 18789
 priority=40
 autostart=false
-autorestart=false
+autorestart=true
 user=node
 directory=/home/node
 environment=HOME="/home/node",USER="node",DISPLAY=":1",PATH="/usr/local/bin:/usr/bin:/bin",PLAYWRIGHT_BROWSERS_PATH="/ms-playwright"


### PR DESCRIPTION
## Summary

- The openclaw gateway process had `autorestart=false` in supervisord config, causing the service to stay permanently down after upstream transient failures (e.g. Discord API 503) until manual intervention
- Change `autorestart` to `true` so supervisord automatically restarts the gateway after crashes
- `autostart=false` remains unchanged (gateway cannot run before onboarding); `supervisorctl stop` behavior is unaffected

## Root Cause

On 2026-03-12 20:36 UTC, all three OpenClaw containers' gateway processes crashed simultaneously: Discord API returned a transient 503 → OpenClaw hit an unhandled promise rejection → Node.js exited. With `autorestart=false`, supervisord did not recover the processes, resulting in 12+ hours of service outage.

## Test plan

- [x] Hot-patched supervisord config and restarted gateway in all 3 running containers, confirmed recovery
- [x] Verified `supervisorctl status` shows openclaw RUNNING
- [x] Verified `/health` endpoint returns `{"ok":true,"status":"live"}`
- [ ] Create a new container to verify `autorestart=true` takes effect in the Docker image

🤖 Generated with [Claude Code](https://claude.com/claude-code)