### PR TITLE
docs: refine README wording and add Wiki cross-references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ---
 
-**You don't need a dedicated server.** If you have a Mac with Apple Silicon, ClawSandbox lets you:
+**No cloud servers, no new hardware — everything runs on the machine you already have.** If you have a Mac with Apple Silicon, ClawSandbox lets you:
 
 - **Deploy OpenClaw in minutes** — fully sandboxed in Docker, completely isolated from everything else on your machine
 - **Run as many as you want** — spin up an entire fleet of OpenClaw instances and experience a one-person company powered by AI
@@ -66,17 +66,17 @@ clawsandbox dashboard serve
 
 Click **"System → Image"** in the Dashboard and build the sandbox image (~1.4 GB, first build takes several minutes).
 
-### 4. Run Your Company
+### 4. Run Your Lobster Company
 
 Think of ClawSandbox as **your AI company**. Assets are the tools and resources your company owns; Fleet is your team of AI employees. You assign different tools to different employees, and put your AI workforce into production.
 
 #### Stock your toolbox
 
-**Assets → Models** — register LLM API keys. These are the "brains" your employees think with. Each model is validated before saving.
+**Assets → Models** — register LLM API keys. These are the "brains" your employees think with. Each model is validated before saving. For step-by-step setup, see the provider guides: [Anthropic](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-Anthropic) | [OpenAI](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-OpenAI) | [Google](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-Google) | [DeepSeek](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-DeepSeek)
 
 ![Models](docs/images/assets-models.png)
 
-**Assets → Channels** — connect messaging platforms (Telegram, Discord, Slack, etc.). These are the "workstations" where your employees serve customers. Optional; validated before saving.
+**Assets → Channels** — connect messaging platforms (Telegram, Discord, Slack, etc.). These are the "workstations" where your employees serve customers. Optional; validated before saving. For step-by-step setup, see the channel guides: [Telegram](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Telegram) | [Discord](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Discord) | [Slack](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Slack) | [Lark](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Lark)
 
 ![Channels](docs/images/assets-channels.png)
 
@@ -84,13 +84,13 @@ Think of ClawSandbox as **your AI company**. Assets are the tools and resources 
 
 **Fleet → Create** — spin up OpenClaw instances. Each one is a new employee joining your company.
 
-**Fleet → Configure** — assign a model and channel from your asset pool to each instance. Different employees can use different tools for different jobs.
+**Fleet → Configure** — assign a model and channel from your asset pool to each instance. Different employees can use different tools for different jobs. See [Dashboard Guide — Fleet Management](https://github.com/weiyong1024/ClawSandbox/wiki/Dashboard-Guide#fleet-management) for details.
 
 ![Fleet](docs/images/fleet.png)
 
 #### Save & clone your employees' souls
 
-Once an employee is trained and performing well, save their soul — personality, memory, model config, and conversation history — so you can clone them instantly.
+Once an employee is trained and performing well, save their soul — personality, memory, model config, and conversation history — so you can clone them instantly. See [Soul Archive](https://github.com/weiyong1024/ClawSandbox/wiki/Soul-Archive) for full documentation.
 
 **Fleet → Save Soul** — click on any configured instance to save its soul to the archive.
 
@@ -119,7 +119,7 @@ See the **[Wiki](https://github.com/weiyong1024/ClawSandbox/wiki)** for full doc
 - Channel guides — [Telegram](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Telegram) | [Discord](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Discord) | [Slack](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Slack) | [Lark](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Lark)
 - [CLI Reference](https://github.com/weiyong1024/ClawSandbox/wiki/CLI-Reference) | [FAQ](https://github.com/weiyong1024/ClawSandbox/wiki/FAQ)
 
-## CLI Reference
+## CLI Reference (for developers)
 
 Every command supports `--help` for detailed usage and examples:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 ---
 
-**不需要额外买一台 Mac Mini。** 只要你有一台 Apple Silicon 的 Mac，ClawSandbox 就能让你：
+**不用买云服务器，不用添置新硬件，一切在你当前的工作机上完成。** 只要你有一台 Apple Silicon 的 Mac，ClawSandbox 就能让你：
 
 - **几分钟部署 OpenClaw** — 完全运行在 Docker 沙箱中，与电脑上的现有资源彻底隔离
 - **想部署多少就部署多少** — 一键拉起 OpenClaw 军团，体验 AI 驱动的一人公司
@@ -66,17 +66,17 @@ clawsandbox dashboard serve
 
 在仪表盘中点击 **「系统 → 镜像管理」**，构建沙箱镜像（约 1.4 GB，首次构建需要几分钟）。
 
-### 4. 经营你的公司
+### 4. 经营你的龙虾公司
 
 把 ClawSandbox 想象成**你的 AI 公司**。资产管理是公司的工具仓库，Fleet 是你的 AI 员工团队。给不同员工分配不同的工具，让你的 AI 团队投入生产。
 
 #### 备好工具库
 
-**资产管理 → Model 配置** — 注册 LLM API Key，这是员工用来思考的「大脑」。保存前自动验证。
+**资产管理 → Model 配置** — 注册 LLM API Key，这是员工用来思考的「大脑」。保存前自动验证。详细配置见各提供商指南：[Anthropic](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-Anthropic) | [OpenAI](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-OpenAI) | [Google](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-Google) | [DeepSeek](https://github.com/weiyong1024/ClawSandbox/wiki/Provider-DeepSeek)
 
 ![Model 配置](docs/images/assets-models.png)
 
-**资产管理 → Channel 配置** — 接入消息平台（Telegram、Discord、Slack 等），这是员工服务客户的「工位」。可选；保存前自动验证。
+**资产管理 → Channel 配置** — 接入消息平台（Telegram、Discord、Slack 等），这是员工服务客户的「工位」。可选；保存前自动验证。详细配置见各频道指南：[Telegram](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Telegram) | [Discord](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Discord) | [Slack](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Slack) | [Lark](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Lark)
 
 ![Channel 配置](docs/images/assets-channels.png)
 
@@ -84,13 +84,13 @@ clawsandbox dashboard serve
 
 **实例管理 → 创建实例** — 创建 OpenClaw 实例，每一个都是加入公司的新员工。
 
-**实例管理 → 配置** — 从资产池为每个实例分配 Model 和 Channel。不同员工可以使用不同的工具，承担不同的任务。
+**实例管理 → 配置** — 从资产池为每个实例分配 Model 和 Channel。不同员工可以使用不同的工具，承担不同的任务。详见 [仪表盘指南 — 实例管理](https://github.com/weiyong1024/ClawSandbox/wiki/Dashboard-Guide#fleet-management)。
 
 ![实例管理](docs/images/fleet.png)
 
 #### 保存与克隆员工的灵魂
 
-当一个员工被训练得足够好时，可以保存它的灵魂——人格、记忆、模型配置和对话历史——以便随时克隆。
+当一个员工被训练得足够好时，可以保存它的灵魂——人格、记忆、模型配置和对话历史——以便随时克隆。详见 [灵魂存档](https://github.com/weiyong1024/ClawSandbox/wiki/Soul-Archive)。
 
 **实例管理 → 灵魂保存** — 点击任意已配置实例，将其灵魂保存到存档。
 
@@ -119,7 +119,7 @@ clawsandbox dashboard serve
 - 频道指南 — [Telegram](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Telegram) | [Discord](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Discord) | [Slack](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Slack) | [Lark](https://github.com/weiyong1024/ClawSandbox/wiki/Channel-Lark)
 - [CLI 参考](https://github.com/weiyong1024/ClawSandbox/wiki/CLI-Reference) | [常见问题](https://github.com/weiyong1024/ClawSandbox/wiki/FAQ)
 
-## CLI 命令
+## CLI 命令（面向开发者）
 
 任何命令都可以加 `--help` 查看详细用法和示例：
 


### PR DESCRIPTION
## Summary

- Update opening tagline to "No cloud servers, no new hardware — everything runs on the machine you already have"
- Rename section 4 to "Run Your Lobster Company"
- Add inline Wiki links to Models (provider guides), Channels (channel guides), Fleet Configure (Dashboard Guide), and Soul Archive sections
- Mark CLI Reference section as "for developers"

## Test plan

- [ ] Verify all Wiki links resolve correctly
- [ ] Check README renders properly on GitHub (EN + ZH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)