### PR TITLE
seo: add LICENSE, badges, and optimize repo metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Wei Yong
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # ClawSandbox
 
-> Deploy and manage a fleet of isolated [OpenClaw](https://github.com/openclaw/openclaw) instances on a single machine.
+[![GitHub release](https://img.shields.io/github/v/release/weiyong1024/ClawSandbox)](https://github.com/weiyong1024/ClawSandbox/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/weiyong1024/ClawSandbox/blob/main/LICENSE)
+[![Go](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![Docker](https://img.shields.io/badge/Docker-required-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
+[![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux-lightgrey)](https://github.com/weiyong1024/ClawSandbox)
+[![Wiki](https://img.shields.io/badge/Docs-Wiki-blue)](https://github.com/weiyong1024/ClawSandbox/wiki)
+
+> Deploy and manage a fleet of isolated [OpenClaw](https://github.com/openclaw/openclaw) instances on a single machine — from a browser dashboard, no CLI needed.
 
 [中文文档](./README.zh-CN.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,13 @@
 # ClawSandbox
 
-> 在单台机器上部署和管理多个隔离的 [OpenClaw](https://github.com/openclaw/openclaw) 实例。
+[![GitHub release](https://img.shields.io/github/v/release/weiyong1024/ClawSandbox)](https://github.com/weiyong1024/ClawSandbox/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/weiyong1024/ClawSandbox/blob/main/LICENSE)
+[![Go](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![Docker](https://img.shields.io/badge/Docker-required-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
+[![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux-lightgrey)](https://github.com/weiyong1024/ClawSandbox)
+[![Wiki](https://img.shields.io/badge/Docs-Wiki-blue)](https://github.com/weiyong1024/ClawSandbox/wiki)
+
+> 在单台机器上部署和管理多个隔离的 [OpenClaw](https://github.com/openclaw/openclaw) 实例 — 打开浏览器即可管理，无需命令行。
 
 [English](./README.md)
 


### PR DESCRIPTION
## Summary
- Add standard MIT LICENSE file (fixes GitHub license detection showing `null`)
- Add badges to both READMEs (release, license, Go, Docker, platform, wiki)
- Update repo description to keyword-rich format for search discoverability
- Set homepage URL to wiki
- Expand topics from 9/20 to 20/20

## Context
Google searches for "ClawSandbox" do not surface our repo. These changes improve GitHub's internal search ranking and external SEO signals through proper metadata, license detection, and badge credibility.

## Test plan
- [ ] After merge, verify `gh api repos/weiyong1024/ClawSandbox --jq '.license.spdx_id'` returns `MIT`
- [ ] Verify badges render correctly on GitHub README
- [ ] Verify 20 topics show on repo page
- [ ] Verify description and homepage URL in repo "About" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)