### PR TITLE
feat: add batch destroy and UI improvements

### DIFF
--- a/internal/cli/configure.go
+++ b/internal/cli/configure.go
@@ -26,6 +26,7 @@ func init() {
 	f.String("model", "", "Model ID (e.g. claude-sonnet-4-6)")
 	f.String("channel", "", "Chat channel (telegram, discord, slack, etc.)")
 	f.String("channel-token", "", "Channel bot token")
+
 	_ = configureCmd.MarkFlagRequired("api-key")
 }
 

--- a/internal/container/configure.go
+++ b/internal/container/configure.go
@@ -43,7 +43,7 @@ func Configure(cli *docker.Client, p ConfigureParams) error {
 		"supervisorctl", "stop", "openclaw",
 	})
 
-	// Step 1: onboard with API key (runs as "node" — writes to ~node/.openclaw/)
+	// Onboard with API key (runs as "node" — writes to ~node/.openclaw/)
 	apiKeyFlag := fmt.Sprintf("--%s-api-key", p.Provider)
 	if err := dockerExecAs(cli, p.ContainerID, "node", []string{
 		"openclaw", "onboard",
@@ -55,7 +55,7 @@ func Configure(cli *docker.Client, p ConfigureParams) error {
 		return fmt.Errorf("onboard: %w", err)
 	}
 
-	// Step 2: set default model (runs as "node")
+	// Set default model (runs as "node").
 	// OpenClaw expects fully qualified model IDs like "openai/gpt-4o".
 	// If the user passes a bare model name, prefix it with the provider.
 	if p.Model != "" {

--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -33,6 +33,8 @@ func Create(cli *docker.Client, p CreateParams) (string, error) {
 		"18789/tcp": {},
 	}
 
+	binds := []string{fmt.Sprintf("%s:/home/node/.openclaw", p.DataDir)}
+
 	container, err := cli.CreateContainer(docker.CreateContainerOptions{
 		Name: p.Name,
 		Config: &docker.Config{
@@ -44,7 +46,7 @@ func Create(cli *docker.Client, p CreateParams) (string, error) {
 			},
 		},
 		HostConfig: &docker.HostConfig{
-			Binds:        []string{fmt.Sprintf("%s:/home/node/.openclaw", p.DataDir)},
+			Binds:        binds,
 			PortBindings: portBindings,
 			NetworkMode:  cfg.NetworkName,
 			Memory:       p.MemoryBytes,
@@ -70,6 +72,12 @@ func Remove(cli *docker.Client, containerID string) error {
 		ID:    containerID,
 		Force: true,
 	})
+}
+
+// IsNotFound returns true if the error indicates the container does not exist.
+func IsNotFound(err error) bool {
+	_, ok := err.(*docker.NoSuchContainer)
+	return ok
 }
 
 // Status returns the container's status string and its StartedAt time (zero if not running).

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -43,6 +43,8 @@ func instanceToResponse(inst state.Instance, assets *state.AssetStore) instanceR
 		if m := assets.GetModel(inst.ModelAssetID); m != nil {
 			resp.ModelName = m.Name
 		}
+	}
+	if assets != nil {
 		if c := assets.GetChannel(inst.ChannelAssetID); c != nil {
 			resp.ChannelName = c.Name
 		}
@@ -281,8 +283,12 @@ func (s *Server) handleDestroyInstance(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := container.Remove(s.docker, inst.ContainerID); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
+		// Container may already be gone (e.g. manually removed or prior race).
+		// Continue to clean up state regardless.
+		if !container.IsNotFound(err) {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
 	}
 
 	store.Remove(name)
@@ -301,6 +307,67 @@ func (s *Server) handleDestroyInstance(w http.ResponseWriter, r *http.Request) {
 
 	s.events.Publish(Event{Type: EventDestroyed, Name: name})
 	writeJSON(w, http.StatusOK, map[string]any{"data": map[string]string{"name": name, "status": "destroyed"}})
+}
+
+// handleBatchDestroyInstances destroys multiple instances in a single request,
+// using a single state load/save cycle to avoid write races.
+func (s *Server) handleBatchDestroyInstances(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Names []string `json:"names"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if len(req.Names) == 0 {
+		writeError(w, http.StatusBadRequest, "names is required")
+		return
+	}
+
+	store, err := s.loadStore()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	purge := r.URL.Query().Get("purge") != "false"
+	destroyed := 0
+
+	for _, name := range req.Names {
+		inst := store.Get(name)
+		if inst == nil {
+			continue
+		}
+
+		if err := container.Remove(s.docker, inst.ContainerID); err != nil && !container.IsNotFound(err) {
+			continue
+		}
+
+		store.Remove(name)
+
+		if assets, err := s.loadAssets(); err == nil {
+			assets.ReleaseChannelByInstance(name)
+			_ = assets.SaveAssets()
+		}
+
+		if purge {
+			dataDir, _ := config.DataDir()
+			_ = os.RemoveAll(filepath.Join(dataDir, "data", name))
+		}
+
+		destroyed++
+	}
+
+	_ = store.Save()
+
+	// Publish a single event to trigger UI refresh.
+	if destroyed > 0 {
+		s.events.Publish(Event{Type: EventDestroyed, Name: req.Names[0]})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": map[string]any{"destroyed": destroyed},
+	})
 }
 
 // handleResetInstance purges the persisted OpenClaw config so the instance
@@ -344,6 +411,10 @@ func (s *Server) handleResetInstance(w http.ResponseWriter, r *http.Request) {
 	} {
 		_ = os.RemoveAll(filepath.Join(instanceDataDir, sub))
 	}
+
+	// Clear config references (model asset, channel asset, mode) so the
+	// instance shows as unconfigured.
+	store.SetConfig(name, "", "")
 
 	// Release any channel assets assigned to this instance.
 	assets, err := s.loadAssets()

--- a/internal/web/handlers_configure.go
+++ b/internal/web/handlers_configure.go
@@ -35,8 +35,8 @@ func (s *Server) handleConfigureInstance(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// If asset IDs are provided, resolve them to actual config values
 	if req.ModelAssetID != "" {
+		// Standard mode with asset IDs: resolve them to actual config values.
 		assets, err := s.loadAssets()
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -13,6 +13,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/instances/{name}/start", s.handleStartInstance)
 	mux.HandleFunc("POST /api/v1/instances/{name}/stop", s.handleStopInstance)
 	mux.HandleFunc("DELETE /api/v1/instances/{name}", s.handleDestroyInstance)
+	mux.HandleFunc("POST /api/v1/instances/batch-destroy", s.handleBatchDestroyInstances)
 	mux.HandleFunc("POST /api/v1/instances/{name}/reset", s.handleResetInstance)
 	mux.HandleFunc("GET /api/v1/instances/{name}/logs", s.handleInstanceLogs)
 	mux.HandleFunc("POST /api/v1/instances/{name}/configure", s.handleConfigureInstance)

--- a/internal/web/static/css/style.css
+++ b/internal/web/static/css/style.css
@@ -256,11 +256,30 @@ body {
 .card-running { border-left: 3px solid var(--success); }
 .card-stopped { border-left: 3px solid var(--text-dim); }
 
+.card-selected {
+  border-color: var(--danger);
+  box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.3);
+}
+
 .card-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 14px;
+}
+
+.card-header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.card-checkbox {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--primary);
+  cursor: pointer;
+  flex-shrink: 0;
 }
 
 .card-name {
@@ -447,9 +466,20 @@ body {
   border-radius: var(--radius);
   width: 100%;
   max-width: 420px;
+  max-height: 70vh;
   margin: 24px;
+  display: flex;
+  flex-direction: column;
   animation: slideUp 0.2s ease;
 }
+
+.dialog > form {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.dialog-body { padding: 20px; overflow-y: auto; min-height: 0; }
 
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
 @keyframes slideUp { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
@@ -478,8 +508,6 @@ body {
   transition: all var(--transition);
 }
 .dialog-close:hover { color: var(--text); background: var(--surface-alt); }
-
-.dialog-body { padding: 20px; }
 
 .form-label {
   display: block;
@@ -878,6 +906,38 @@ body {
   align-items: center;
   justify-content: space-between;
   margin-bottom: 24px;
+}
+
+.page-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ── Batch Selection Bar ── */
+.batch-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 24px;
+  margin-bottom: 8px;
+}
+
+.batch-select-all {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.82rem;
+  color: var(--text-dim);
+  cursor: pointer;
+  user-select: none;
+}
+
+.batch-select-all input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--primary);
+  cursor: pointer;
 }
 
 .page-title {

--- a/internal/web/static/js/api.js
+++ b/internal/web/static/js/api.js
@@ -24,6 +24,7 @@ export const api = {
   startInstance:  (name)        => request('POST',   `/instances/${encodeURIComponent(name)}/start`),
   stopInstance:   (name)        => request('POST',   `/instances/${encodeURIComponent(name)}/stop`),
   destroyInstance:(name)        => request('DELETE',  `/instances/${encodeURIComponent(name)}`),
+  batchDestroyInstances:(names) => request('POST',  '/instances/batch-destroy', { names }),
   resetInstance:  (name)        => request('POST',   `/instances/${encodeURIComponent(name)}/reset`),
   configureInstance: (name, config) => request('POST', `/instances/${encodeURIComponent(name)}/configure`, config),
   getConfigStatus:   (name)        => request('GET',  `/instances/${encodeURIComponent(name)}/configure/status`),

--- a/internal/web/static/js/app.js
+++ b/internal/web/static/js/app.js
@@ -47,6 +47,7 @@ function App() {
   const [connected, setConnected] = useState(true);
   const [configureName, setConfigureName] = useState(null);
   const [snapshotName, setSnapshotName] = useState(null);
+  const [selected, setSelected] = useState(new Set());
   const { toasts, addToast, removeToast } = useToast();
 
   useEffect(() => {
@@ -155,6 +156,38 @@ function App() {
     }
   };
 
+  const onToggleSelect = useCallback((name) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name); else next.add(name);
+      return next;
+    });
+  }, []);
+
+  const onSelectAll = useCallback(() => {
+    setSelected(prev => {
+      if (prev.size === instances.length) return new Set();
+      return new Set(instances.map(i => i.name));
+    });
+  }, [instances]);
+
+  const onBatchDestroy = async () => {
+    const names = [...selected];
+    if (names.length === 0) return;
+    if (!confirm(t('confirm.batchDestroy', names.length))) return;
+    for (const name of names) {
+      setPending(p => ({ ...p, [name]: 'destroying' }));
+    }
+    try {
+      const result = await api.batchDestroyInstances(names);
+      addToast(t('toast.batchDestroyed', result.destroyed), 'success');
+    } catch (err) {
+      addToast(err.message, 'error');
+    }
+    setPending({});
+    setSelected(new Set());
+  };
+
   useEffect(() => {
     const onKey = (e) => {
       if (e.key === 'Escape' && showCreate) setShowCreate(false);
@@ -209,6 +242,10 @@ function App() {
           stats=${stats}
           loading=${loading}
           pending=${pending}
+          selected=${selected}
+          onToggleSelect=${onToggleSelect}
+          onSelectAll=${onSelectAll}
+          onBatchDestroy=${onBatchDestroy}
           onStart=${onStart}
           onStop=${onStop}
           onDestroy=${onDestroy}

--- a/internal/web/static/js/components/dashboard.js
+++ b/internal/web/static/js/components/dashboard.js
@@ -13,7 +13,7 @@ function SkeletonCard() {
   `;
 }
 
-export function Dashboard({ instances, stats, loading, pending, onStart, onStop, onDestroy, onDesktop, onConfigure, onSnapshot, onCreateClick }) {
+export function Dashboard({ instances, stats, loading, pending, selected, onToggleSelect, onSelectAll, onBatchDestroy, onStart, onStop, onDestroy, onDesktop, onConfigure, onSnapshot, onCreateClick }) {
   const { t } = useLang();
 
   if (loading) {
@@ -26,13 +26,23 @@ export function Dashboard({ instances, stats, loading, pending, onStart, onStop,
     `;
   }
 
+  const selectedCount = selected.size;
+  const allSelected = instances.length > 0 && selectedCount === instances.length;
+
   return html`
     <div class="page-content">
       <div class="page-header">
         <h2 class="page-title">${t('sidebar.instances')} <span class="toolbar-count">${t('toolbar.instances', instances.length)}</span></h2>
-        <button class="btn btn-primary" onClick=${onCreateClick}>
-          ${t('toolbar.create')}
-        </button>
+        <div class="page-header-actions">
+          ${selectedCount > 0 && html`
+            <button class="btn btn-danger" onClick=${onBatchDestroy}>
+              ${t('batch.destroy', selectedCount)}
+            </button>
+          `}
+          <button class="btn btn-primary" onClick=${onCreateClick}>
+            ${t('toolbar.create')}
+          </button>
+        </div>
       </div>
 
       ${instances.length === 0 ? html`
@@ -42,6 +52,17 @@ export function Dashboard({ instances, stats, loading, pending, onStart, onStop,
           <p>${t('dashboard.empty.desc')}</p>
         </div>
       ` : html`
+        ${instances.length > 1 && html`
+          <div class="batch-bar">
+            <label class="batch-select-all">
+              <input type="checkbox"
+                checked=${allSelected}
+                ref=${(el) => { if (el) el.indeterminate = selectedCount > 0 && !allSelected; }}
+                onChange=${onSelectAll} />
+              <span>${allSelected ? t('batch.deselectAll') : t('batch.selectAll')}</span>
+            </label>
+          </div>
+        `}
         <div class="dashboard-grid">
           ${instances.map(inst => html`
             <${InstanceCard}
@@ -49,6 +70,8 @@ export function Dashboard({ instances, stats, loading, pending, onStart, onStop,
               instance=${inst}
               stats=${stats[inst.name]}
               pending=${pending[inst.name]}
+              selected=${selected.has(inst.name)}
+              onToggleSelect=${onToggleSelect}
               onStart=${() => onStart(inst.name)}
               onStop=${() => onStop(inst.name)}
               onDestroy=${() => onDestroy(inst.name)}

--- a/internal/web/static/js/components/instance-card.js
+++ b/internal/web/static/js/components/instance-card.js
@@ -2,7 +2,7 @@ import { html } from '../lib.js';
 import { useLang } from '../i18n.js';
 import { formatBytes } from '../utils.js';
 
-export function InstanceCard({ instance, stats, pending, onStart, onStop, onDestroy, onDesktop, onConfigure, onSnapshot }) {
+export function InstanceCard({ instance, stats, pending, selected, onToggleSelect, onStart, onStop, onDestroy, onDesktop, onConfigure, onSnapshot }) {
   const { t } = useLang();
   const isRunning = instance.status === 'running';
   const cpu = stats?.cpu_percent ?? 0;
@@ -16,9 +16,14 @@ export function InstanceCard({ instance, stats, pending, onStart, onStop, onDest
     : isRunning ? instance.status : t('status.suspended');
 
   return html`
-    <div class="card ${isRunning ? 'card-running' : 'card-stopped'} ${busy ? 'card-busy' : ''}">
+    <div class="card ${isRunning ? 'card-running' : 'card-stopped'} ${busy ? 'card-busy' : ''} ${selected ? 'card-selected' : ''}">
       <div class="card-header">
-        <div class="card-name">${instance.name}</div>
+        <div class="card-header-left">
+          <input type="checkbox" class="card-checkbox"
+            checked=${selected}
+            onClick=${(e) => { e.stopPropagation(); onToggleSelect(instance.name); }} />
+          <div class="card-name">${instance.name}</div>
+        </div>
         <span class="status-badge ${isRunning ? 'status-running' : 'status-stopped'}">
           <span class="status-dot"></span>
           ${statusLabel}

--- a/internal/web/static/js/i18n.js
+++ b/internal/web/static/js/i18n.js
@@ -49,6 +49,13 @@ const messages = {
     'toast.stopped':         (name) => `Suspended ${name}`,
     'toast.destroyed':       (name) => `Destroyed ${name}`,
     'confirm.destroy':       (name) => `Destroy ${name}? This removes the container.`,
+    'confirm.batchDestroy':  (n) => `Destroy ${n} selected instance${n > 1 ? 's' : ''}? This cannot be undone.`,
+
+    'batch.selectAll':       'Select All',
+    'batch.deselectAll':     'Deselect All',
+    'batch.destroy':         (n) => `Destroy ${n} Selected`,
+    'toast.batchDestroyed':  (n) => `Destroyed ${n} instance(s)`,
+    'toast.batchDestroyFailed': (n) => `Failed to destroy ${n} instance(s)`,
 
     'action.starting':       'Resuming...',
     'action.stopping':       'Suspending...',
@@ -194,6 +201,13 @@ const messages = {
     'toast.stopped':         (name) => `已挂起 ${name}`,
     'toast.destroyed':       (name) => `已销毁 ${name}`,
     'confirm.destroy':       (name) => `确定销毁 ${name}？这将移除容器。`,
+    'confirm.batchDestroy':  (n) => `确定销毁 ${n} 个选中的实例？此操作不可撤销。`,
+
+    'batch.selectAll':       '全选',
+    'batch.deselectAll':     '取消全选',
+    'batch.destroy':         (n) => `销毁 ${n} 个选中`,
+    'toast.batchDestroyed':  (n) => `已销毁 ${n} 个实例`,
+    'toast.batchDestroyFailed': (n) => `${n} 个实例销毁失败`,
 
     'action.starting':       '复位中...',
     'action.stopping':       '挂起中...',


### PR DESCRIPTION
## Summary

- **Batch destroy**: New `POST /api/v1/instances/batch-destroy` endpoint with single state load/save cycle, avoiding the write race condition that caused ghost instances when destroying multiple instances via parallel individual DELETE requests
- **Multi-select UI**: Checkbox on each instance card, "Select All" bar, and batch destroy button in the page header
- **Dialog scroll fix**: Configure dialog now scrolls internally (`max-height: 70vh`, flex column layout) instead of overflowing the screen when content is long
- **Bug fixes**: Destroy handler tolerates `NoSuchContainer` errors; reset handler now clears config references (`SetConfig`)

## Test plan

- [x] Create 3+ instances, verify cards show checkboxes
- [x] Select all / deselect all via header checkbox
- [x] Batch destroy selected instances — all removed in one operation, no ghost cards
- [x] Single destroy still works as before
- [x] Configure dialog with many model configs scrolls within the dialog
- [x] Standard mode configure flow unaffected
- [x] API smoke tests: create, configure, batch-destroy, list

🤖 Generated with [Claude Code](https://claude.com/claude-code)