### PR TITLE
fix: add explicit roleplay instruction to SOUL.md character injection

### DIFF
--- a/internal/container/configure.go
+++ b/internal/container/configure.go
@@ -355,6 +355,7 @@ type SoulParams struct {
 func InjectSoul(cli *docker.Client, containerID string, p SoulParams) error {
 	var sb strings.Builder
 	sb.WriteString("# " + p.Name + "\n")
+	sb.WriteString("\n**You are " + p.Name + ". Stay in character at all times. Every response must reflect this persona's voice, personality, and perspective. Never break character or revert to a generic assistant.**\n")
 	if p.Bio != "" {
 		sb.WriteString("\n## Bio\n" + p.Bio + "\n")
 	}


### PR DESCRIPTION
## Summary
- In messaging channels with heavy metadata (e.g. Feishu group chats), the LLM ignored SOUL.md character definitions for less iconic personas (SteveJobs, RayKroc) and fell back to generic assistant behavior, while highly recognizable characters (Tony Stark) worked fine
- Root cause: the generated SOUL.md was purely descriptive (a character sheet) without an explicit roleplay directive — the metadata noise from group chats diluted the character signal for weaker personas
- Fix: inject a forceful "stay in character" instruction at the top of SOUL.md, immediately after the character name heading

## Debugging trail
1. Verified SOUL.md files existed with correct content in all 4 containers
2. Confirmed `systemPromptReport.injectedWorkspaceFiles` showed SOUL.md was included (not missing, not truncated) in the system prompt for both working and broken instances
3. Tested `openclaw agent --local` and `openclaw agent --session-id` — both correctly responded in character, narrowing the issue to the Feishu group chat message path
4. Identified that the Feishu group chat metadata (sender info, mention tags, group context) created enough noise to override weaker character signals

## Test plan
- [x] `make build` and `make test` pass
- [x] Live-verified on claw-3 (SteveJobs@Feishu) — now responds in character
- [x] Live-verified on claw-4 (RayKroc@Feishu) — now responds in character
- [x] claw-1 (TonyStark@Discord) and claw-2 (TonyStark@Feishu) continue working

🤖 Generated with [Claude Code](https://claude.com/claude-code)