### PR TITLE
docs: remove Slack-specific detail from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Think of ClawFleet as **your AI company**. Assets are the tools and resources yo
 
 ![Characters](docs/images/assets-characters.png)
 
-**Assets → Channels** — connect messaging platforms (Telegram, Discord, Slack, etc.). These are the "workstations" where your employees serve customers. Optional; validated before saving. Slack follows OpenClaw Socket Mode and uses both a Bot Token and an App Token.
+**Assets → Channels** — connect messaging platforms (Telegram, Discord, Slack, etc.). These are the "workstations" where your employees serve customers. Optional; validated before saving.
 
 ![Channels](docs/images/assets-channels.png)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -89,7 +89,7 @@ clawfleet dashboard serve
 
 ![Character 配置](docs/images/assets-characters.png)
 
-**资产管理 → Channel 配置** — 接入消息平台（Telegram、Discord、Slack 等），这是员工服务客户的「工位」。可选；保存前自动验证。Slack 跟随 OpenClaw 默认的 Socket Mode，需要同时提供 Bot Token 和 App Token。
+**资产管理 → Channel 配置** — 接入消息平台（Telegram、Discord、Slack 等），这是员工服务客户的「工位」。可选；保存前自动验证。
 
 ![Channel 配置](docs/images/assets-channels.png)
 


### PR DESCRIPTION
## Summary

- Remove Slack Socket Mode / dual-token implementation detail from both README.md and README.zh-CN.md
- This is channel-specific info that belongs in the wiki, not the product overview
- Slack wiki documentation will be added separately by yingapple

🤖 Generated with [Claude Code](https://claude.com/claude-code)