### PR TITLE
fix: use latest image for non-release builds

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 package version
 
-import "strings"
+import "regexp"
 
 // Injected at build time via ldflags. See Makefile / .goreleaser.yml.
 var (
@@ -9,21 +9,16 @@ var (
 	BuildDate = "unknown"
 )
 
+var releaseTagPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+
 // ImageTag returns the Docker image tag corresponding to this CLI version.
-// Release builds (e.g. "v0.1.0") use the version directly; dev builds fall
-// back to "latest". Git metadata suffixes like "-dirty" or "-3-gabcdef" are
-// stripped so the tag always matches a real image.
+// Only exact release tags (e.g. "v0.1.0") map to release images. Local git
+// describe builds such as "v0.1.0-44-gabcdef" or dirty builds fall back to
+// "latest" so development binaries do not accidentally target an old release
+// image.
 func ImageTag() string {
-	if Version == "dev" {
-		return "latest"
+	if releaseTagPattern.MatchString(Version) {
+		return Version
 	}
-	tag := Version
-	tag = strings.TrimSuffix(tag, "-dirty")
-	// Strip git describe distance suffix (e.g. "v0.1.0-3-gabcdef" → "v0.1.0")
-	if idx := strings.Index(tag, "-"); idx > 0 {
-		if rest := tag[idx+1:]; len(rest) > 0 && rest[0] >= '0' && rest[0] <= '9' {
-			tag = tag[:idx]
-		}
-	}
-	return tag
+	return "latest"
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,30 @@
+package version
+
+import "testing"
+
+func TestImageTag(t *testing.T) {
+	original := Version
+	t.Cleanup(func() {
+		Version = original
+	})
+
+	tests := []struct {
+		version string
+		want    string
+	}{
+		{version: "dev", want: "latest"},
+		{version: "unknown", want: "latest"},
+		{version: "v0.1.0", want: "v0.1.0"},
+		{version: "1.2.3", want: "1.2.3"},
+		{version: "v0.1.0-dirty", want: "latest"},
+		{version: "v0.1.0-3-gabcdef", want: "latest"},
+		{version: "v0.1.0-44-g27e904a-dirty", want: "latest"},
+	}
+
+	for _, tt := range tests {
+		Version = tt.version
+		if got := ImageTag(); got != tt.want {
+			t.Fatalf("ImageTag() for %q = %q, want %q", tt.version, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- treat only exact release tags as release image tags
- make local `git describe` and dirty builds default to `latest`
- add unit coverage for release, dev, dirty, and `git describe` version strings

## Problem
`internal/version.ImageTag()` currently trims `-dirty` and `-<distance>-g<sha>` suffixes from the CLI version string.

That behavior is correct for exact release builds, but it is incorrect for local development builds. For example, a local binary built from `v0.1.0-44-g27e904a-dirty` currently resolves its default image tag to `v0.1.0` instead of `latest`.

As a result, a freshly built local CLI or Dashboard can silently create instances from an older release image instead of the intended development image.

## Fix
This change makes `ImageTag()` return the version string only when it is an exact release tag such as `v0.1.0` or `1.2.3`.

All non-release builds now fall back to `latest`, including:
- `dev`
- `unknown`
- `v0.1.0-dirty`
- `v0.1.0-3-gabcdef`
- `v0.1.0-44-g27e904a-dirty`

## Validation
- `go test ./internal/version ./...`
