### PR TITLE
fix: use pure-Go TLS verification to avoid macOS stale handle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endef
 
 build:
 	@mkdir -p $(BUILD_DIR)
-	$(call run-go,"$$GO_BIN" build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/clawfleet)
+	$(call run-go,env CGO_ENABLED=0 "$$GO_BIN" build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/clawfleet)
 
 build-all:
 	@mkdir -p $(BUILD_DIR)

--- a/internal/web/validate.go
+++ b/internal/web/validate.go
@@ -1,6 +1,8 @@
 package web
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,7 +11,19 @@ import (
 	"time"
 )
 
-var httpClient = &http.Client{Timeout: 15 * time.Second}
+var httpClient = newValidationHTTPClient()
+
+// newValidationHTTPClient creates an HTTP client that uses Go's pure-Go TLS
+// certificate verification instead of delegating to macOS Security framework.
+// This avoids "SecPolicyCreateSSL error: 0" failures that occur when a
+// long-running process's handle to the macOS Security framework becomes stale.
+func newValidationHTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if pool, err := x509.SystemCertPool(); err == nil {
+		transport.TLSClientConfig = &tls.Config{RootCAs: pool}
+	}
+	return &http.Client{Timeout: 15 * time.Second, Transport: transport}
+}
 
 // ValidateModelKey validates an API key by calling the provider's models endpoint.
 func ValidateModelKey(provider, apiKey, model string) error {


### PR DESCRIPTION
## Summary
- Fix "SecPolicyCreateSSL error: 0" TLS failures that occur when the dashboard process runs for extended periods on macOS
- Configure HTTP validation client with explicit system cert pool (`x509.SystemCertPool`) so Go uses its own pure-Go TLS verification instead of delegating to macOS Security framework
- Set `CGO_ENABLED=0` in default `make build` target for consistency with `build-all`

## Test plan
- [x] Reproduced the TLS error on the running dashboard (`POST /api/v1/assets/models/test` returned `SecPolicyCreateSSL error: 0`)
- [x] Rebuilt and restarted dashboard — model test now returns expected `HTTP 401` (valid TLS, invalid dummy key)
- [x] User confirmed GPT-5.4 test works correctly in Dashboard UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)