### PR TITLE
chore: migrate repo references to clawfleet org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @weiyong1024
+* @clawfleet/maintainers

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,9 +14,9 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - -s -w
-      - -X github.com/weiyong1024/clawfleet/internal/version.Version=v{{.Version}}
-      - -X github.com/weiyong1024/clawfleet/internal/version.GitCommit={{.ShortCommit}}
-      - -X github.com/weiyong1024/clawfleet/internal/version.BuildDate={{.Date}}
+      - -X github.com/clawfleet/clawfleet/internal/version.Version=v{{.Version}}
+      - -X github.com/clawfleet/clawfleet/internal/version.GitCommit={{.ShortCommit}}
+      - -X github.com/clawfleet/clawfleet/internal/version.BuildDate={{.Date}}
     goos:
       - darwin
       - linux
@@ -44,7 +44,7 @@ changelog:
 
 release:
   github:
-    owner: weiyong1024
+    owner: clawfleet
     name: ClawFleet
   prerelease: auto
   name_template: "v{{.Version}}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ All design decisions, project structure, and code implementation must follow bes
 
 ## Wiki Documentation
 
-The project wiki lives in a separate repo (`git@github.com:weiyong1024/ClawFleet.wiki.git`) and is browsable at `https://github.com/weiyong1024/ClawFleet/wiki`. It is the primary documentation hub beyond the README.
+The project wiki lives in a separate repo (`git@github.com:clawfleet/ClawFleet.wiki.git`) and is browsable at `https://github.com/clawfleet/ClawFleet/wiki`. It is the primary documentation hub beyond the README.
 
 ### Wiki structure
 
@@ -183,7 +183,7 @@ Screenshots in `docs/images/` serve dual purposes: README documentation and exte
 ### How to edit the wiki
 
 ```bash
-git clone git@github.com:weiyong1024/ClawFleet.wiki.git /tmp/ClawFleet.wiki
+git clone git@github.com:clawfleet/ClawFleet.wiki.git /tmp/ClawFleet.wiki
 cd /tmp/ClawFleet.wiki
 # Edit files...
 git add . && git commit -m "describe the change" && git push

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BINARY     = clawfleet
 BUILD_DIR  = ./bin
-MODULE     = github.com/weiyong1024/clawfleet
+MODULE     = github.com/clawfleet/clawfleet
 IMAGE      = ghcr.io/clawfleet/clawfleet:latest
 GO_BOOTSTRAP = ./scripts/ensure-go.sh --print-path
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ClawFleet
 
-[![GitHub release](https://img.shields.io/github/v/release/weiyong1024/ClawFleet)](https://github.com/weiyong1024/ClawFleet/releases)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/weiyong1024/ClawFleet/blob/main/LICENSE)
+[![GitHub release](https://img.shields.io/github/v/release/clawfleet/ClawFleet)](https://github.com/clawfleet/ClawFleet/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/clawfleet/ClawFleet/blob/main/LICENSE)
 [![Go](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 [![Docker](https://img.shields.io/badge/Docker-required-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
-[![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux-lightgrey)](https://github.com/weiyong1024/ClawFleet)
-[![Wiki](https://img.shields.io/badge/Docs-Wiki-blue)](https://github.com/weiyong1024/ClawFleet/wiki)
+[![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux-lightgrey)](https://github.com/clawfleet/ClawFleet)
+[![Wiki](https://img.shields.io/badge/Docs-Wiki-blue)](https://github.com/clawfleet/ClawFleet/wiki)
 
 🌐 **Website:** [clawfleet.io](https://clawfleet.io) · 💬 **Community:** [Discord](https://discord.gg/b5ZSRyrqbt)
 
@@ -64,7 +64,7 @@ This single command will:
 4. Start the Dashboard as a background daemon
 5. Open http://localhost:8080 in your browser
 
-> **Manual install?** See the [Getting Started](https://github.com/weiyong1024/ClawFleet/wiki/Getting-Started) wiki page.
+> **Manual install?** See the [Getting Started](https://github.com/clawfleet/ClawFleet/wiki/Getting-Started) wiki page.
 
 ### Run Your Company
 
@@ -128,12 +128,12 @@ Connect your fleet to messaging platforms and watch your AI employees work toget
 
 ## Documentation
 
-See the **[Wiki](https://github.com/weiyong1024/ClawFleet/wiki)** for full documentation, including:
-- [Getting Started](https://github.com/weiyong1024/ClawFleet/wiki/Getting-Started) — prerequisites, install, first instance
-- [Dashboard Guide](https://github.com/weiyong1024/ClawFleet/wiki/Dashboard-Guide) — sidebar navigation, asset management, fleet management
-- LLM Provider guides — [Anthropic](https://github.com/weiyong1024/ClawFleet/wiki/Provider-Anthropic) | [OpenAI](https://github.com/weiyong1024/ClawFleet/wiki/Provider-OpenAI) | [Google](https://github.com/weiyong1024/ClawFleet/wiki/Provider-Google) | [DeepSeek](https://github.com/weiyong1024/ClawFleet/wiki/Provider-DeepSeek)
-- Channel guides — [Telegram](https://github.com/weiyong1024/ClawFleet/wiki/Channel-Telegram) | [Discord](https://github.com/weiyong1024/ClawFleet/wiki/Channel-Discord) | [Slack](https://github.com/weiyong1024/ClawFleet/wiki/Channel-Slack) | [Lark](https://github.com/weiyong1024/ClawFleet/wiki/Channel-Lark)
-- [CLI Reference](https://github.com/weiyong1024/ClawFleet/wiki/CLI-Reference) | [FAQ](https://github.com/weiyong1024/ClawFleet/wiki/FAQ)
+See the **[Wiki](https://github.com/clawfleet/ClawFleet/wiki)** for full documentation, including:
+- [Getting Started](https://github.com/clawfleet/ClawFleet/wiki/Getting-Started) — prerequisites, install, first instance
+- [Dashboard Guide](https://github.com/clawfleet/ClawFleet/wiki/Dashboard-Guide) — sidebar navigation, asset management, fleet management
+- LLM Provider guides — [Anthropic](https://github.com/clawfleet/ClawFleet/wiki/Provider-Anthropic) | [OpenAI](https://github.com/clawfleet/ClawFleet/wiki/Provider-OpenAI) | [Google](https://github.com/clawfleet/ClawFleet/wiki/Provider-Google) | [DeepSeek](https://github.com/clawfleet/ClawFleet/wiki/Provider-DeepSeek)
+- Channel guides — [Telegram](https://github.com/clawfleet/ClawFleet/wiki/Channel-Telegram) | [Discord](https://github.com/clawfleet/ClawFleet/wiki/Channel-Discord) | [Slack](https://github.com/clawfleet/ClawFleet/wiki/Channel-Slack) | [Lark](https://github.com/clawfleet/ClawFleet/wiki/Channel-Lark)
+- [CLI Reference](https://github.com/clawfleet/ClawFleet/wiki/CLI-Reference) | [FAQ](https://github.com/clawfleet/ClawFleet/wiki/FAQ)
 
 ## CLI Reference
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,11 +1,11 @@
 # ClawFleet
 
-[![GitHub release](https://img.shields.io/github/v/release/weiyong1024/ClawFleet)](https://github.com/weiyong1024/ClawFleet/releases)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/weiyong1024/ClawFleet/blob/main/LICENSE)
+[![GitHub release](https://img.shields.io/github/v/release/clawfleet/ClawFleet)](https://github.com/clawfleet/ClawFleet/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/clawfleet/ClawFleet/blob/main/LICENSE)
 [![Go](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 [![Docker](https://img.shields.io/badge/Docker-required-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
-[![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux-lightgrey)](https://github.com/weiyong1024/ClawFleet)
-[![Wiki](https://img.shields.io/badge/Docs-Wiki-blue)](https://github.com/weiyong1024/ClawFleet/wiki)
+[![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux-lightgrey)](https://github.com/clawfleet/ClawFleet)
+[![Wiki](https://img.shields.io/badge/Docs-Wiki-blue)](https://github.com/clawfleet/ClawFleet/wiki)
 
 🌐 **官网:** [clawfleet.io](https://clawfleet.io) · 💬 **社区:** [Discord](https://discord.gg/b5ZSRyrqbt)
 
@@ -64,7 +64,7 @@ curl -fsSL https://clawfleet.io/install.sh | sh
 4. 以后台守护进程启动仪表盘
 5. 在浏览器中打开 http://localhost:8080
 
-> **手动安装？** 参阅[快速入门](https://github.com/weiyong1024/ClawFleet/wiki/Getting-Started)。
+> **手动安装？** 参阅[快速入门](https://github.com/clawfleet/ClawFleet/wiki/Getting-Started)。
 
 ### 经营你的公司
 
@@ -128,12 +128,12 @@ curl -fsSL https://clawfleet.io/install.sh | sh
 
 ## 文档
 
-完整文档请参阅 **[Wiki](https://github.com/weiyong1024/ClawFleet/wiki)**，包括：
-- [快速开始](https://github.com/weiyong1024/ClawFleet/wiki/Getting-Started) — 前置要求、安装、第一个实例
-- [仪表盘指南](https://github.com/weiyong1024/ClawFleet/wiki/Dashboard-Guide) — 侧边栏导航、资产管理、实例管理
-- LLM 提供商指南 — [Anthropic](https://github.com/weiyong1024/ClawFleet/wiki/Provider-Anthropic) | [OpenAI](https://github.com/weiyong1024/ClawFleet/wiki/Provider-OpenAI) | [Google](https://github.com/weiyong1024/ClawFleet/wiki/Provider-Google) | [DeepSeek](https://github.com/weiyong1024/ClawFleet/wiki/Provider-DeepSeek)
-- 频道指南 — [Telegram](https://github.com/weiyong1024/ClawFleet/wiki/Channel-Telegram) | [Discord](https://github.com/weiyong1024/ClawFleet/wiki/Channel-Discord) | [Slack](https://github.com/weiyong1024/ClawFleet/wiki/Channel-Slack) | [Lark](https://github.com/weiyong1024/ClawFleet/wiki/Channel-Lark)
-- [CLI 参考](https://github.com/weiyong1024/ClawFleet/wiki/CLI-Reference) | [常见问题](https://github.com/weiyong1024/ClawFleet/wiki/FAQ)
+完整文档请参阅 **[Wiki](https://github.com/clawfleet/ClawFleet/wiki)**，包括：
+- [快速开始](https://github.com/clawfleet/ClawFleet/wiki/Getting-Started) — 前置要求、安装、第一个实例
+- [仪表盘指南](https://github.com/clawfleet/ClawFleet/wiki/Dashboard-Guide) — 侧边栏导航、资产管理、实例管理
+- LLM 提供商指南 — [Anthropic](https://github.com/clawfleet/ClawFleet/wiki/Provider-Anthropic) | [OpenAI](https://github.com/clawfleet/ClawFleet/wiki/Provider-OpenAI) | [Google](https://github.com/clawfleet/ClawFleet/wiki/Provider-Google) | [DeepSeek](https://github.com/clawfleet/ClawFleet/wiki/Provider-DeepSeek)
+- 频道指南 — [Telegram](https://github.com/clawfleet/ClawFleet/wiki/Channel-Telegram) | [Discord](https://github.com/clawfleet/ClawFleet/wiki/Channel-Discord) | [Slack](https://github.com/clawfleet/ClawFleet/wiki/Channel-Slack) | [Lark](https://github.com/clawfleet/ClawFleet/wiki/Channel-Lark)
+- [CLI 参考](https://github.com/clawfleet/ClawFleet/wiki/CLI-Reference) | [常见问题](https://github.com/clawfleet/ClawFleet/wiki/FAQ)
 
 ## CLI 命令
 

--- a/cmd/clawfleet/main.go
+++ b/cmd/clawfleet/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/weiyong1024/clawfleet/internal/cli"
+	"github.com/clawfleet/clawfleet/internal/cli"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/weiyong1024/clawfleet
+module github.com/clawfleet/clawfleet
 
 go 1.25.0
 

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
-	"github.com/weiyong1024/clawfleet/internal/container"
-	"github.com/weiyong1024/clawfleet/internal/version"
+	"github.com/clawfleet/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/version"
 )
 
 var buildCmd = &cobra.Command{

--- a/internal/cli/config_show.go
+++ b/internal/cli/config_show.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/config"
 )
 
 var configCmd = &cobra.Command{

--- a/internal/cli/configure.go
+++ b/internal/cli/configure.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/container"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 var configureCmd = &cobra.Command{

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
-	"github.com/weiyong1024/clawfleet/internal/container"
-	"github.com/weiyong1024/clawfleet/internal/port"
-	"github.com/weiyong1024/clawfleet/internal/snapshot"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/port"
+	"github.com/clawfleet/clawfleet/internal/snapshot"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 var pullFlag bool

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/config"
 )
 
 // ServiceManager abstracts platform-specific daemon management.

--- a/internal/cli/daemon_linux.go
+++ b/internal/cli/daemon_linux.go
@@ -13,7 +13,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/config"
 )
 
 // NewServiceManager returns systemd if available, otherwise falls back to PID-based.

--- a/internal/cli/daemon_other.go
+++ b/internal/cli/daemon_other.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/config"
 )
 
 // NewServiceManager returns a PID-based ServiceManager on unsupported platforms.

--- a/internal/cli/dashboard_serve.go
+++ b/internal/cli/dashboard_serve.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
-	"github.com/weiyong1024/clawfleet/internal/container"
-	"github.com/weiyong1024/clawfleet/internal/web"
+	"github.com/clawfleet/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/web"
 )
 
 var dashboardServePort int

--- a/internal/cli/dashboard_stop.go
+++ b/internal/cli/dashboard_stop.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/config"
 )
 
 var dashboardStopCmd = &cobra.Command{

--- a/internal/cli/desktop.go
+++ b/internal/cli/desktop.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/container"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 var desktopCmd = &cobra.Command{

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
-	"github.com/weiyong1024/clawfleet/internal/container"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 var destroyPurge bool

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 // resolveTargets returns copies of the instances matching name, or all instances if name == "all".

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/container"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 var listCmd = &cobra.Command{

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/container"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 var logsFollow bool

--- a/internal/cli/restart.go
+++ b/internal/cli/restart.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/container"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 var restartCmd = &cobra.Command{

--- a/internal/cli/snapshot_delete.go
+++ b/internal/cli/snapshot_delete.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/snapshot"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/snapshot"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 var snapshotDeleteCmd = &cobra.Command{

--- a/internal/cli/snapshot_list.go
+++ b/internal/cli/snapshot_list.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 var snapshotListCmd = &cobra.Command{

--- a/internal/cli/snapshot_save.go
+++ b/internal/cli/snapshot_save.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/snapshot"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/snapshot"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 var (

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/container"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 var startCmd = &cobra.Command{

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/container"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 var stopCmd = &cobra.Command{

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/weiyong1024/clawfleet/internal/version"
+	"github.com/clawfleet/clawfleet/internal/version"
 )
 
 var versionShort bool

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/weiyong1024/clawfleet/internal/version"
+	"github.com/clawfleet/clawfleet/internal/version"
 )
 
 const (

--- a/internal/container/image.go
+++ b/internal/container/image.go
@@ -10,7 +10,7 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 
-	"github.com/weiyong1024/clawfleet/internal/assets"
+	"github.com/clawfleet/clawfleet/internal/assets"
 )
 
 func ImageExists(cli *docker.Client, imageRef string) (bool, error) {

--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -10,7 +10,7 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 
-	cfg "github.com/weiyong1024/clawfleet/internal/config"
+	cfg "github.com/clawfleet/clawfleet/internal/config"
 )
 
 type CreateParams struct {

--- a/internal/container/network.go
+++ b/internal/container/network.go
@@ -5,7 +5,7 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/config"
 )
 
 // EnsureNetwork creates the "clawfleet-net" container network if it does not

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 var validName = regexp.MustCompile(`^[\p{L}\p{N}][\p{L}\p{N} _-]{0,63}$`)

--- a/internal/state/assets.go
+++ b/internal/state/assets.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/config"
 )
 
 // ModelAsset represents a pre-configured LLM provider + API key + model combination.

--- a/internal/state/snapshots.go
+++ b/internal/state/snapshots.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/config"
 )
 
 // SnapshotMeta holds metadata for a saved instance snapshot.

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/config"
 )
 
 type Ports struct {

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
-	"github.com/weiyong1024/clawfleet/internal/container"
-	"github.com/weiyong1024/clawfleet/internal/port"
-	"github.com/weiyong1024/clawfleet/internal/snapshot"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/port"
+	"github.com/clawfleet/clawfleet/internal/snapshot"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 // instanceResponse is the JSON representation of a single instance.

--- a/internal/web/handlers_assets.go
+++ b/internal/web/handlers_assets.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 func generateID() string {

--- a/internal/web/handlers_configure.go
+++ b/internal/web/handlers_configure.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/weiyong1024/clawfleet/internal/container"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 // configureRequest is the JSON body for POST /api/v1/instances/{name}/configure.

--- a/internal/web/handlers_image.go
+++ b/internal/web/handlers_image.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/weiyong1024/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/container"
 )
 
 // handleImageStatus reports whether the sandbox Docker image has been built.

--- a/internal/web/handlers_skills.go
+++ b/internal/web/handlers_skills.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/weiyong1024/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/container"
 )
 
 // handleListInstanceSkills returns all skills available in the specified instance.

--- a/internal/web/handlers_snapshots.go
+++ b/internal/web/handlers_snapshots.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/weiyong1024/clawfleet/internal/snapshot"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/snapshot"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 func (s *Server) loadSnapshots() (*state.SnapshotStore, error) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -15,8 +15,8 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 
-	"github.com/weiyong1024/clawfleet/internal/config"
-	"github.com/weiyong1024/clawfleet/internal/state"
+	"github.com/clawfleet/clawfleet/internal/config"
+	"github.com/clawfleet/clawfleet/internal/state"
 )
 
 // Server is the ClawFleet Web UI HTTP server.

--- a/internal/web/ws_logs.go
+++ b/internal/web/ws_logs.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	"github.com/weiyong1024/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/container"
 )
 
 // handleWSLogs streams container logs over a WebSocket (follow mode).

--- a/internal/web/ws_stats.go
+++ b/internal/web/ws_stats.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	"github.com/weiyong1024/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/container"
 )
 
 // wsUpgrader is shared by all WebSocket handlers.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-REPO="weiyong1024/ClawFleet"
+REPO="clawfleet/ClawFleet"
 BINARY="clawfleet"
 IMAGE_REPO="ghcr.io/clawfleet/clawfleet"
 DOCKER_CMD="docker"
@@ -370,7 +370,7 @@ print_success() {
   printf "    clawfleet create 3           Create 3 instances\n"
   printf "    clawfleet list               List all instances\n"
   printf "\n"
-  printf "  Docs:    ${CYAN}https://github.com/weiyong1024/ClawFleet/wiki${RESET}\n"
+  printf "  Docs:    ${CYAN}https://github.com/clawfleet/ClawFleet/wiki${RESET}\n"
   printf "\n"
 }
 


### PR DESCRIPTION
## Summary

Repo transferred from `weiyong1024/ClawFleet` to `clawfleet/ClawFleet`. This PR updates all references:

- Go module path: `github.com/weiyong1024/clawfleet` → `github.com/clawfleet/clawfleet`
- GoReleaser release owner → `clawfleet`
- install.sh, README, CLAUDE.md GitHub URLs
- CODEOWNERS

**Must merge before tagging a release**, otherwise GoReleaser and CI will target the old namespace.

## Test plan
- [x] `make build` + `make test` pass
- [x] Cross-compile all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)