### PR TITLE
feat: OpenClaw version selector

### DIFF
--- a/internal/assets/docker/Dockerfile
+++ b/internal/assets/docker/Dockerfile
@@ -35,7 +35,8 @@ RUN mv /usr/bin/chromium /usr/bin/chromium-real \
     && update-alternatives --set x-www-browser /usr/bin/chromium
 
 # ── Layer 2: OpenClaw ─────────────────────────────────────────────────────────
-RUN npm install -g openclaw@latest \
+ARG OPENCLAW_VERSION=latest
+RUN npm install -g openclaw@${OPENCLAW_VERSION} \
     && if [ -d /usr/local/lib/node_modules/openclaw/extensions/feishu ]; then \
          cd /usr/local/lib/node_modules/openclaw/extensions/feishu && npm install --omit=dev; \
        fi

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -11,6 +11,8 @@ import (
 	"github.com/clawfleet/clawfleet/internal/version"
 )
 
+var openclawVersionFlag string
+
 var buildCmd = &cobra.Command{
 	Use:   "build",
 	Short: "Build the OpenClaw sandbox Docker image",
@@ -18,8 +20,13 @@ var buildCmd = &cobra.Command{
 This is only needed for offline use or customization.
 When connected to the internet, 'clawfleet create' auto-pulls the
 pre-built image from GHCR.`,
-	Example: "  clawfleet build",
+	Example: "  clawfleet build\n  clawfleet build --openclaw-version 2026.3.24",
 	RunE:    runBuild,
+}
+
+func init() {
+	buildCmd.Flags().StringVar(&openclawVersionFlag, "openclaw-version", "",
+		"OpenClaw version to install (default: recommended "+version.RecommendedOpenClawVersion+")")
 }
 
 func runBuild(cmd *cobra.Command, args []string) error {
@@ -33,10 +40,15 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	imageRef := cfg.ImageRef()
-	fmt.Fprintf(os.Stdout, "Building image %s ...\n\n", imageRef)
+	ocVersion := openclawVersionFlag
+	if ocVersion == "" {
+		ocVersion = version.RecommendedOpenClawVersion
+	}
 
-	if err := container.Build(cli, imageRef, os.Stdout); err != nil {
+	imageRef := cfg.ImageRef()
+	fmt.Fprintf(os.Stdout, "Building image %s with OpenClaw %s ...\n\n", imageRef, ocVersion)
+
+	if err := container.Build(cli, imageRef, ocVersion, os.Stdout); err != nil {
 		return fmt.Errorf("build failed: %w", err)
 	}
 

--- a/internal/container/client.go
+++ b/internal/container/client.go
@@ -11,5 +11,15 @@ func NewClient() (*docker.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("connecting to Docker: %w\nIs Docker running?", err)
 	}
+	// Negotiate API version with the Docker daemon so the client works
+	// with any Docker Engine version (old library default is too low for
+	// modern Docker Desktop).
+	if env, err := cli.Version(); err == nil {
+		if apiVer := env.Get("ApiVersion"); apiVer != "" {
+			if negotiated, err := docker.NewVersionedClientFromEnv(apiVer); err == nil {
+				return negotiated, nil
+			}
+		}
+	}
 	return cli, nil
 }

--- a/internal/container/image.go
+++ b/internal/container/image.go
@@ -28,10 +28,18 @@ func ImageExists(cli *docker.Client, imageRef string) (bool, error) {
 	return false, nil
 }
 
-func Build(cli *docker.Client, imageRef string, out io.Writer) error {
+func Build(cli *docker.Client, imageRef string, openclawVersion string, out io.Writer) error {
 	buildCtx, err := createBuildContext()
 	if err != nil {
 		return fmt.Errorf("creating build context: %w", err)
+	}
+
+	var buildArgs []docker.BuildArg
+	if openclawVersion != "" {
+		buildArgs = append(buildArgs, docker.BuildArg{
+			Name:  "OPENCLAW_VERSION",
+			Value: openclawVersion,
+		})
 	}
 
 	err = cli.BuildImage(docker.BuildImageOptions{
@@ -39,6 +47,7 @@ func Build(cli *docker.Client, imageRef string, out io.Writer) error {
 		InputStream:    buildCtx,
 		OutputStream:   out,
 		RmTmpContainer: true,
+		BuildArgs:      buildArgs,
 	})
 	if err != nil {
 		return fmt.Errorf("build failed: %w", err)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,6 +11,10 @@ var (
 
 var releaseTagPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
 
+// RecommendedOpenClawVersion is the OpenClaw version that has been tested
+// with this release of ClawFleet. Updated with each ClawFleet release.
+const RecommendedOpenClawVersion = "2026.3.24"
+
 // ImageTag returns the Docker image tag corresponding to this CLI version.
 // Only exact release tags (e.g. "v0.1.0") map to release images. Local git
 // describe builds such as "v0.1.0-44-gabcdef" or dirty builds fall back to

--- a/internal/web/handlers_image.go
+++ b/internal/web/handlers_image.go
@@ -2,11 +2,17 @@ package web
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/version"
 )
 
 // handleImageStatus reports whether the sandbox Docker image has been built.
@@ -24,8 +30,124 @@ func (s *Server) handleImageStatus(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleOpenClawVersions queries the npm registry and returns available OpenClaw versions.
+func (s *Server) handleOpenClawVersions(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://registry.npmjs.org/openclaw", nil)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create request")
+		return
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		// Registry unreachable — return only the recommended version.
+		writeJSON(w, http.StatusOK, map[string]any{
+			"data": map[string]any{
+				"recommended": version.RecommendedOpenClawVersion,
+				"versions":    []string{version.RecommendedOpenClawVersion},
+				"latest":      "",
+				"error":       "npm registry unreachable",
+			},
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "reading registry response")
+		return
+	}
+
+	var registry struct {
+		Versions map[string]json.RawMessage `json:"versions"`
+		DistTags map[string]string          `json:"dist-tags"`
+	}
+	if err := json.Unmarshal(body, &registry); err != nil {
+		writeError(w, http.StatusInternalServerError, "parsing registry response")
+		return
+	}
+
+	versions := make([]string, 0, len(registry.Versions))
+	for v := range registry.Versions {
+		versions = append(versions, v)
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		return versionLess(versions[j], versions[i]) // descending
+	})
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": map[string]any{
+			"recommended": version.RecommendedOpenClawVersion,
+			"versions":    versions,
+			"latest":      registry.DistTags["latest"],
+		},
+	})
+}
+
+// versionLess compares two dot-separated version strings numerically.
+// Works for both semver (1.2.3) and date-based (2026.3.24) versioning.
+// Pre-release versions (e.g. 2026.3.24-beta.1) sort before their release.
+func versionLess(a, b string) bool {
+	aBase, aIsPrerelease := splitPrerelease(a)
+	bBase, bIsPrerelease := splitPrerelease(b)
+
+	pa := parseVersionParts(aBase)
+	pb := parseVersionParts(bBase)
+	for i := 0; i < len(pa) || i < len(pb); i++ {
+		va, vb := 0, 0
+		if i < len(pa) {
+			va = pa[i]
+		}
+		if i < len(pb) {
+			vb = pb[i]
+		}
+		if va != vb {
+			return va < vb
+		}
+	}
+	// Same base version — pre-release < release.
+	if aIsPrerelease != bIsPrerelease {
+		return aIsPrerelease
+	}
+	return a < b // both pre-release: lexicographic fallback
+}
+
+// splitPrerelease splits "2026.3.24-beta.1" into ("2026.3.24", true).
+func splitPrerelease(v string) (string, bool) {
+	v = strings.TrimPrefix(v, "v")
+	if idx := strings.IndexByte(v, '-'); idx >= 0 {
+		return v[:idx], true
+	}
+	return v, false
+}
+
+func parseVersionParts(v string) []int {
+	parts := strings.Split(v, ".")
+	nums := make([]int, len(parts))
+	for i, p := range parts {
+		nums[i], _ = strconv.Atoi(p)
+	}
+	return nums
+}
+
 // handleImageBuild triggers a Docker image build and streams progress via SSE.
 func (s *Server) handleImageBuild(w http.ResponseWriter, r *http.Request) {
+	// Parse optional JSON body for openclaw_version.
+	openclawVersion := version.RecommendedOpenClawVersion
+	if r.Body != nil && r.ContentLength != 0 {
+		var req struct {
+			OpenClawVersion string `json:"openclaw_version"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err == nil && req.OpenClawVersion != "" {
+			openclawVersion = req.OpenClawVersion
+		}
+	}
+
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		writeError(w, http.StatusInternalServerError, "streaming not supported")
@@ -36,12 +158,15 @@ func (s *Server) handleImageBuild(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
+	writeSSE(w, "log", fmt.Sprintf("Building with OpenClaw %s", openclawVersion))
+	flusher.Flush()
+
 	imageRef := s.config.ImageRef()
 	pr, pw := newLineWriter(r.Context())
 
 	done := make(chan error, 1)
 	go func() {
-		done <- container.Build(s.docker, imageRef, pw)
+		done <- container.Build(s.docker, imageRef, openclawVersion, pw)
 		pw.Close()
 	}()
 

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -20,6 +20,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/instances/{name}/configure/status", s.handleConfigureStatus)
 	mux.HandleFunc("POST /api/v1/instances/{name}/restart-bot", s.handleRestartBot)
 	mux.HandleFunc("GET /api/v1/image/status", s.handleImageStatus)
+	mux.HandleFunc("GET /api/v1/image/openclaw-versions", s.handleOpenClawVersions)
 	mux.HandleFunc("POST /api/v1/image/build", s.handleImageBuild)
 	mux.HandleFunc("POST /api/v1/image/pull", s.handleImagePull)
 

--- a/internal/web/static/css/style.css
+++ b/internal/web/static/css/style.css
@@ -1231,6 +1231,9 @@ body {
   line-height: 1.7;
 }
 
+.image-version-select { max-width: 360px; margin-top: 0; }
+.image-version-hint   { font-size: 0.82rem; color: var(--text-dim); }
+
 /* ── Responsive ── */
 @media (max-width: 960px) {
   .desktop-body { flex-direction: column; }

--- a/internal/web/static/js/api.js
+++ b/internal/web/static/js/api.js
@@ -31,7 +31,8 @@ export const api = {
   getConfigStatus:   (name)        => request('GET',  `/instances/${encodeURIComponent(name)}/configure/status`),
 
   // Image
-  imageStatus: () => request('GET', '/image/status'),
+  imageStatus:      () => request('GET', '/image/status'),
+  openclawVersions: () => request('GET', '/image/openclaw-versions'),
 
   // Model assets
   listModelAssets:  ()           => request('GET',    '/assets/models'),

--- a/internal/web/static/js/components/image-page.js
+++ b/internal/web/static/js/components/image-page.js
@@ -32,6 +32,9 @@ export function ImagePage({ addToast }) {
   const [pulling, setPulling] = useState(false);
   const [pullLogs, setPullLogs] = useState([]);
   const [selectedFlavor, setSelectedFlavor] = useState('lightweight');
+  const [versions, setVersions] = useState(null);
+  const [selectedVersion, setSelectedVersion] = useState('');
+  const [versionsLoading, setVersionsLoading] = useState(true);
 
   const checkStatus = useCallback(async () => {
     try {
@@ -44,12 +47,27 @@ export function ImagePage({ addToast }) {
     }
   }, []);
 
-  useEffect(() => { checkStatus(); }, [checkStatus]);
+  const loadVersions = useCallback(async () => {
+    setVersionsLoading(true);
+    try {
+      const data = await api.openclawVersions();
+      setVersions(data);
+      setSelectedVersion(data.recommended);
+      if (data.error) addToast(t('image.versionError'), 'warning');
+    } catch {
+      setVersions({ recommended: '', versions: [], latest: '' });
+      addToast(t('image.versionError'), 'error');
+    } finally {
+      setVersionsLoading(false);
+    }
+  }, []);
 
-  const readSSE = async (endpoint, setLogs, successKey, failKey) => {
+  useEffect(() => { checkStatus(); loadVersions(); }, [checkStatus, loadVersions]);
+
+  const readSSE = async (endpoint, setLogs, successKey, failKey, fetchInit = {}) => {
     const proto = location.protocol === 'https:' ? 'https:' : 'http:';
     const url = `${proto}//${location.host}${endpoint}`;
-    const response = await fetch(url, { method: 'POST' });
+    const response = await fetch(url, { method: 'POST', ...fetchInit });
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     let buffer = '';
@@ -94,7 +112,10 @@ export function ImagePage({ addToast }) {
     setBuilding(true);
     setBuildLogs([]);
     try {
-      await readSSE('/api/v1/image/build', setBuildLogs, 'image.buildSuccess', 'image.buildFailed');
+      await readSSE('/api/v1/image/build', setBuildLogs, 'image.buildSuccess', 'image.buildFailed', {
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ openclaw_version: selectedVersion }),
+      });
     } catch (err) {
       addToast(err.message, 'error');
     } finally {
@@ -140,6 +161,35 @@ export function ImagePage({ addToast }) {
             </div>
           `)}
         </div>
+      </div>
+
+      <div class="image-section">
+        <h3 class="section-title">${t('image.openclawVersion')}</h3>
+        ${versionsLoading
+          ? html`<p class="image-version-hint">${t('image.versionLoading')}</p>`
+          : html`
+            <select class="form-input image-version-select"
+              value=${selectedVersion}
+              onChange=${(e) => setSelectedVersion(e.target.value)}
+              disabled=${building || pulling}
+            >
+              ${versions?.recommended && html`
+                <option value=${versions.recommended}>
+                  ${versions.recommended} ★ ${t('image.versionRecommended')}
+                </option>
+              `}
+              ${versions?.latest && versions.latest !== versions.recommended && html`
+                <option value=${versions.latest}>
+                  ${versions.latest} (${t('image.versionLatest')})
+                </option>
+              `}
+              ${(versions?.versions || [])
+                .filter(v => v !== versions?.recommended && v !== versions?.latest)
+                .map(v => html`<option key=${v} value=${v}>${v}</option>`)
+              }
+            </select>
+          `
+        }
       </div>
 
       <div class="image-section">

--- a/internal/web/static/js/i18n.js
+++ b/internal/web/static/js/i18n.js
@@ -188,6 +188,11 @@ const messages = {
     'image.buildLog':        'Build Log',
     'image.buildSuccess':    'Image built successfully',
     'image.buildFailed':     'Image build failed',
+    'image.openclawVersion':   'OpenClaw Version',
+    'image.versionLoading':    'Loading versions...',
+    'image.versionError':      'Could not fetch version list',
+    'image.versionRecommended':'recommended',
+    'image.versionLatest':     'latest',
 
     // Snapshots
     'sidebar.snapshots':       'Soul Archive',
@@ -399,6 +404,11 @@ const messages = {
     'image.buildLog':        '构建日志',
     'image.buildSuccess':    '镜像构建成功',
     'image.buildFailed':     '镜像构建失败',
+    'image.openclawVersion':   'OpenClaw 版本',
+    'image.versionLoading':    '加载版本中...',
+    'image.versionError':      '无法获取版本列表',
+    'image.versionRecommended':'推荐',
+    'image.versionLatest':     '最新',
 
     // Snapshots
     'sidebar.snapshots':       '灵魂存档',


### PR DESCRIPTION
## Summary

- Build 镜像时可选 OpenClaw 版本，默认推荐已测试版本（2026.3.24），降低上游 breaking changes 导致的构建失败
- Dashboard Image 页面新增版本下拉框（推荐版本 ★ → latest → 历史版本降序）
- 后端查询 npm registry 获取版本列表，npm 不可达时降级为仅推荐版本
- CLI 新增 `--openclaw-version` flag
- Docker client 自动协商 API 版本，修复新版 Docker Desktop 的兼容性问题

## Changed files (11 files, +237/-11)

| Layer | File | Change |
|-------|------|--------|
| Docker | `Dockerfile` | `ARG OPENCLAW_VERSION` parameterize npm install |
| Backend | `version.go` | `RecommendedOpenClawVersion` constant |
| Backend | `image.go` | `Build()` accepts version, passes as Docker build-arg |
| Backend | `client.go` | API version negotiation with Docker daemon |
| Backend | `handlers_image.go` | New `GET /openclaw-versions` + build accepts version |
| Backend | `routes.go` | Register new route |
| CLI | `build.go` | `--openclaw-version` flag |
| Frontend | `image-page.js` | Version dropdown + build sends selected version |
| Frontend | `api.js` | `openclawVersions()` method |
| Frontend | `i18n.js` | 5 new EN + ZH keys |
| Frontend | `style.css` | Version selector styles |

## Test plan

- [x] `make build` — compiles
- [x] `make test` — all tests pass
- [x] Mac M4 (darwin/arm64): API endpoints, CLI flag, Dashboard UI, Docker build
- [x] Ubuntu 24.04 (linux/amd64): API endpoints, CLI flag, Docker build
- [x] Version sort: release before beta, descending order
- [x] Backward compat: empty POST body falls back to recommended version
- [x] npm registry unreachable: degrades to recommended version only

🤖 Generated with [Claude Code](https://claude.com/claude-code)