### PR TITLE
docs: add Prompt-Bearing Markdown is Code principle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,13 @@ All design decisions, project structure, and code implementation must follow bes
 - Don't add abstractions, flags, or config options for hypothetical future needs. Solve the current problem directly.
 - Prefer calling existing CLI tools (`docker exec` + `openclaw` CLI) over writing config files directly — this keeps the integration resilient to upstream format changes.
 
+### Prompt-Bearing Markdown is Code
+- SOUL.md drives bot persona and behavior at runtime. Treat its content with the same rigor as source code — not "good enough" prose.
+- Every prompt section must have: explicit judgment criteria (when to act), negative constraints (when NOT to act), and dense, scannable information (no lore dumps).
+- Expect iteration. The first draft of a prompt section is never the final version. Test actual LLM behavior, observe output, adjust wording.
+- When modifying SOUL.md rendering logic (e.g. `RenderSoulMarkdown`, roster injection), verify the generated Markdown reads correctly as a prompt — not just that the Go code compiles.
+- This principle applies to any Markdown file that is consumed by an LLM at runtime (SOUL.md today, potentially others in the future).
+
 ### Verify Before Handoff
 - After fixing a bug or implementing a feature that affects API/server behavior, smoke-test the change yourself (e.g. `curl` requests to the local server, `docker exec` commands) before asking the user to verify on the UI.
 


### PR DESCRIPTION
## Summary
- Add "Prompt-Bearing Markdown is Code" as a new engineering principle in CLAUDE.md
- SOUL.md drives bot behavior at runtime — its content must be treated with source-code rigor, not "good enough" prose
- Codifies lessons from researching Karpathy's AutoResearch `program.md` pattern ahead of the Roster feature

## Context
As we build the Roster feature (SOUL.md team info injection), this principle ensures all contributors treat prompt-bearing Markdown with the same discipline as Go code: explicit judgment criteria, negative constraints, dense information, and iterative testing against actual LLM output.

## Test plan
- [x] CLAUDE.md renders correctly on GitHub
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)