### PR TITLE
fix: lock OpenClaw version in CI Docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,12 @@ jobs:
         id: meta
         run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
+      - name: Extract recommended OpenClaw version
+        id: openclaw
+        run: |
+          ver=$(grep 'RecommendedOpenClawVersion =' internal/version/version.go | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
       - uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -55,6 +61,8 @@ jobs:
           context: internal/assets/docker
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            OPENCLAW_VERSION=${{ steps.openclaw.outputs.version }}
           tags: |
             ghcr.io/clawfleet/clawfleet:${{ steps.meta.outputs.version }}
             ghcr.io/clawfleet/clawfleet:latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,12 @@ All design decisions, project structure, and code implementation must follow bes
 - Prefer explicit configuration over implicit defaults. If a third-party tool has a default that doesn't suit our use case (e.g. `dmPolicy: "pairing"`), set the desired value explicitly rather than hoping users will figure it out.
 - When orchestrating multi-step processes, respect ordering dependencies and readiness checks (e.g. wait for a service to be healthy before issuing commands against it).
 
+### Version Pinning & Stability Buffer
+- ClawFleet's core value to users is shielding them from OpenClaw's rapid release cadence and potential instability. Every ClawFleet release (e.g. `v0.4.0`) must pin a specific, tested OpenClaw version (`RecommendedOpenClawVersion` in `internal/version/version.go`).
+- The pre-built Docker image on GHCR must contain exactly that pinned version — never `@latest`. CI extracts `RecommendedOpenClawVersion` from source and passes it as the `OPENCLAW_VERSION` build-arg. If this is missing or broken, users get an untested OpenClaw version, defeating the entire purpose of our version management.
+- Before bumping `RecommendedOpenClawVersion`, the new OpenClaw version must be tested end-to-end (instance creation, configuration, bot startup, channel connectivity) on at least one platform.
+- The Dashboard's "Build" flow lets advanced users opt into a different OpenClaw version at their own risk. The "Pull" flow and `install.sh` always deliver the pinned version.
+
 ### Simplicity & Minimal Surface
 - Don't add abstractions, flags, or config options for hypothetical future needs. Solve the current problem directly.
 - Prefer calling existing CLI tools (`docker exec` + `openclaw` CLI) over writing config files directly — this keeps the integration resilient to upstream format changes.
@@ -142,6 +148,12 @@ The output of any tech research should be a clear recommendation: compete / inte
 
 ### Verify Before Handoff
 - After fixing a bug or implementing a feature that affects API/server behavior, smoke-test the change yourself (e.g. `curl` requests to the local server, `docker exec` commands) before asking the user to verify on the UI.
+
+## Growth Strategy Sync
+
+<!-- strategy-bulletin-version: 1 -->
+
+All Marketer-Sessions (growth, content, distribution) MUST re-read `growth/STRATEGY_BULLETIN.md` before every action cycle (writing content, publishing, making distribution decisions). This file contains the live strategy, target user definition, active decisions, and constraints. It is updated by the lead Marketer-Session; the version comment above is bumped on each update to trigger CLAUDE.md change notifications to all running sessions.
 
 ## Wiki Documentation
 

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -1,7 +1,6 @@
-# ClawSandbox System Design
+# ClawFleet System Design
 
-> Version: v0.1 (Draft)
-> Date: 2026-03-07
+> Version: v0.4 | Date: 2026-03-30
 
 [中文文档](./SYSTEM_DESIGN.zh-CN.md)
 
@@ -9,282 +8,353 @@
 
 ## 1. Overview
 
-ClawSandbox is a CLI tool that creates and manages multiple isolated OpenClaw instances on a single host machine. Each instance runs in its own Docker container with a full Linux desktop environment, accessible from any browser via noVNC. Users interact with each instance independently through Telegram.
+ClawFleet deploys and manages a fleet of isolated OpenClaw instances on a single machine, from a browser dashboard. Each instance runs in its own Docker container with a full Linux desktop (XFCE4 + TigerVNC + noVNC), accessible from any browser. Users manage their fleet — create instances, configure LLM providers, assign messaging channels, define character personas, and monitor resources — entirely through the web dashboard or CLI.
 
-## 2. System Architecture
+## 2. Architecture Layers
+
+ClawFleet is built on ClawSandbox, a purpose-built infrastructure layer for container orchestration and instance lifecycle management.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                    Host Machine (macOS / Linux)              │
-│                                                             │
-│  ┌───────────────────────────────────┐                      │
-│  │        ClawSandbox CLI (Go)       │                      │
-│  │  ┌─────────┬──────────┬────────┐  │                      │
-│  │  │ create  │  list    │ desktop│  │                      │
-│  │  │ start   │  stop    │destroy │  │                      │
-│  │  └─────────┴──────────┴────────┘  │                      │
-│  │  ┌─────────────────────────────┐  │                      │
-│  │  │   Docker Engine SDK (Go)    │  │                      │
-│  │  └──────────────┬──────────────┘  │                      │
-│  │                 │                 │                      │
-│  │  ┌──────────────┴──────────────┐  │                      │
-│  │  │     Port Allocator          │  │                      │
-│  │  │  noVNC: 6901, 6902, ...     │  │                      │
-│  │  │  Gateway: 18789, 18790, ... │  │                      │
-│  │  └─────────────────────────────┘  │                      │
-│  │  ┌─────────────────────────────┐  │                      │
-│  │  │     Instance State Store    │  │                      │
-│  │  │  ~/.clawfleet/state.json  │  │                      │
-│  │  └─────────────────────────────┘  │                      │
-│  └───────────────────────────────────┘                      │
-│                     │ Docker API                            │
-│    ┌────────────────┼────────────────────────┐              │
-│    │                │                        │              │
-│    ▼                ▼                        ▼              │
-│  ┌──────────┐  ┌──────────┐           ┌──────────┐         │
-│  │claw-1 │  │claw-2 │    ...    │claw-N │         │
-│  │          │  │          │           │          │         │
-│  │ XFCE     │  │ XFCE     │           │ XFCE     │         │
-│  │ noVNC    │  │ noVNC    │           │ noVNC    │         │
-│  │ Node≥22  │  │ Node≥22  │           │ Node≥22  │         │
-│  │ Chromium │  │ Chromium │           │ Chromium │         │
-│  │ OpenClaw │  │ OpenClaw │           │ OpenClaw │         │
-│  │ Gateway  │  │ Gateway  │           │ Gateway  │         │
-│  └──────────┘  └──────────┘           └──────────┘         │
-│   :6901/:18789  :6902/:18790           :690N/:1878(8+N)    │
+│                   Browser (Dashboard UI)                     │
+│              Preact SPA @ http://localhost:8080              │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ REST API + WebSocket
+┌──────────────────────────▼──────────────────────────────────┐
+│                  ClawFleet (Product Layer)                    │
+│  internal/web/ + internal/cli/                               │
+│  REST API, WebSocket streams, asset management, skills,      │
+│  i18n, roster, snapshots, daemon management                  │
+├─────────────────────────────────────────────────────────────┤
+│                ClawSandbox (Infrastructure Layer)             │
+│  internal/container/, /state/, /port/, /config/,             │
+│  /assets/, /snapshot/, /version/                             │
+│  Docker orchestration, state persistence, port allocation    │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ Docker API (go-dockerclient)
+┌──────────────────────────▼──────────────────────────────────┐
+│                      Docker Engine                           │
+│  ┌──────────┐  ┌──────────┐           ┌──────────┐          │
+│  │ claw-1   │  │ claw-2   │    ...    │ claw-N   │          │
+│  │ XFCE4    │  │ XFCE4    │           │ XFCE4    │          │
+│  │ noVNC    │  │ noVNC    │           │ noVNC    │          │
+│  │ OpenClaw │  │ OpenClaw │           │ OpenClaw │          │
+│  │ Gateway  │  │ Gateway  │           │ Gateway  │          │
+│  └──────────┘  └──────────┘           └──────────┘          │
+│   :6901/:18789  :6902/:18790           :690N/:1878(8+N)     │
 └─────────────────────────────────────────────────────────────┘
 ```
 
+**Dependency rule:** ClawFleet → ClawSandbox (never reverse).
+
 ## 3. Component Design
 
-### 3.1 ClawSandbox CLI
+### 3.1 CLI
 
-**Stack:**
-- Language: Go 1.25+
-- CLI framework: [cobra](https://github.com/spf13/cobra)
-- Docker integration: [go-dockerclient](https://github.com/fsouza/go-dockerclient)
-- Artifact: single statically-linked binary (darwin/arm64, darwin/amd64, linux/amd64, linux/arm64)
+**Stack:** Go 1.25+, Cobra, go-dockerclient. Single statically-linked binary for darwin/linux × amd64/arm64.
 
 **Commands:**
 
-```
-clawfleet build                       # Build the Docker image
-clawfleet create <N>                  # Create N claw instances
-clawfleet list                        # List all instances and their status
-clawfleet start <name|all>            # Start a stopped instance
-clawfleet stop <name|all>             # Stop a running instance
-clawfleet destroy <name|all>          # Destroy instance (data kept by default)
-clawfleet destroy --purge <name|all>  # Destroy instance and delete its data
-clawfleet desktop <name>              # Open an instance's desktop in the browser
-clawfleet logs <name> [-f]            # View instance logs
-```
+| Group | Command | Description |
+|-------|---------|-------------|
+| Fleet | `create <N>` | Create N instances |
+| | `list` | List all instances with status |
+| | `start <name\|all>` | Start stopped instance(s) |
+| | `stop <name\|all>` | Stop running instance(s) |
+| | `restart <name\|all>` | Restart instance(s) |
+| | `destroy <name\|all> [--purge]` | Destroy instance(s), optionally delete data |
+| | `desktop <name>` | Open noVNC desktop in browser |
+| | `logs <name> [-f]` | View/tail container logs |
+| | `configure <name>` | Interactive configuration wizard |
+| Dashboard | `dashboard serve` | Start web server (foreground) |
+| | `dashboard start [--host --port]` | Start as background daemon |
+| | `dashboard stop` | Stop daemon |
+| | `dashboard restart` | Restart daemon |
+| | `dashboard status` | Check daemon status |
+| Image | `build` | Build Docker image locally |
+| Snapshot | `snapshot save <name>` | Archive instance soul |
+| | `snapshot list` | List saved souls |
+| | `snapshot delete <name>` | Delete saved soul |
+| System | `config` | Show config file |
+| | `version` | Print version info |
 
-**Config file:** `~/.clawfleet/config.yaml`
+### 3.2 Web Dashboard
 
-```yaml
-image:
-  name: "ghcr.io/clawfleet/clawfleet"
-  tag: "latest"
+An embedded Preact SPA served by the Go HTTP server at port 8080.
 
-ports:
-  novnc_start: 6901      # noVNC base port, allocated sequentially
-  gateway_start: 18789   # Gateway base port, allocated sequentially
+**REST API (25+ endpoints):**
 
-resources:
-  memory_limit: "4g"     # Per-container memory cap
-  cpu_limit: "2.0"       # Per-container CPU cap (cores)
+| Category | Endpoints | Purpose |
+|----------|-----------|---------|
+| Instances | `GET/POST /instances`, `POST /{name}/start\|stop`, `DELETE /{name}`, `POST /batch-destroy`, `POST /{name}/configure`, `GET /{name}/configure/status`, `POST /{name}/restart-bot`, `POST /{name}/reset` | Full instance lifecycle |
+| Assets | `GET/POST/PUT/DELETE /assets/models`, `/assets/channels`, `/assets/characters`, `POST /assets/models/test`, `POST /assets/channels/test` | Model, channel, character CRUD with validation |
+| Skills | `GET /{name}/skills`, `POST /{name}/skills/install`, `DELETE /{name}/skills/{slug}`, `GET /skills/search` | Skill management via ClawHub |
+| Snapshots | `GET/POST/DELETE /snapshots` | Soul archival |
+| Image | `GET /image/status`, `POST /image/build`, `POST /image/pull`, `GET /image/openclaw-versions` | Image lifecycle + OpenClaw version selector |
 
-naming:
-  prefix: "claw"      # Instance names: claw-1, claw-2, ...
-```
+**WebSocket streams:**
 
-### 3.2 Docker Image (ghcr.io/clawfleet/clawfleet)
+| Endpoint | Purpose |
+|----------|---------|
+| `/ws/stats` | Real-time CPU/memory per instance |
+| `/ws/logs/{name}` | Live container log stream |
+| `/ws/events` | Lifecycle events (create, start, stop, etc.) |
 
-**Base image:** `node:22-bookworm` — consistent with OpenClaw's official Docker setup.
+**Console proxy:** `/console/{name}` reverse-proxies to the instance's noVNC desktop, enabling embedded desktop access within the Dashboard. Gateway LAN bridge (`0.0.0.0:18790`) allows the proxy to reach the Gateway UI.
+
+**Frontend components (21):** toolbar, sidebar, dashboard, instance-card, instance-desktop, create-dialog, configure-dialog, image-page, logs-viewer, model/channel/character asset pages and dialogs, skills, skill-manager-dialog, snapshots, snapshot-dialog, stats-chart, connection-status, toast.
+
+**i18n:** English and Chinese, switchable from the toolbar.
+
+### 3.3 Docker Image
+
+**Registry:** `ghcr.io/clawfleet/clawfleet`
+
+**Base image:** `node:22-bookworm`
 
 **Layer design:**
 
-```dockerfile
-# Layer 1: System packages + desktop environment
-FROM node:22-bookworm
-
-RUN apt-get update && apt-get install -y \
-    xfce4 xfce4-terminal \
-    tigervnc-standalone-server \
-    novnc websockify \
-    dbus-x11 \
-    chromium \
-    fonts-noto-cjk \
-    supervisor curl wget \
-    && rm -rf /var/lib/apt/lists/*
-
-# Wrap Chromium with --no-sandbox (required inside containers)
-RUN mv /usr/bin/chromium /usr/bin/chromium-real \
-    && printf '#!/bin/sh\nexec /usr/bin/chromium-real --no-sandbox "$@"\n' > /usr/bin/chromium \
-    && chmod +x /usr/bin/chromium
-
-# Layer 2: OpenClaw
-RUN npm install -g openclaw@latest
-
-# Layer 3: Playwright Chromium (installed at build time to avoid runtime downloads)
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN node /usr/local/lib/node_modules/openclaw/node_modules/playwright-core/cli.js install chromium
-
-# Layer 4: Startup configuration
-COPY supervisord.conf /etc/supervisor/supervisord.conf
-COPY entrypoint.sh /entrypoint.sh
-
-EXPOSE 6901 18789
-ENTRYPOINT ["/entrypoint.sh"]
-```
+| Layer | Content | Size |
+|-------|---------|------|
+| 1 | System packages: XFCE4, TigerVNC, noVNC, Chromium, CJK fonts, supervisord | ~800 MB |
+| 2 | OpenClaw: `npm install -g openclaw@${OPENCLAW_VERSION}` + feishu extension | ~300 MB |
+| 3 | Playwright Chromium: pre-installed at `/ms-playwright` | ~300 MB |
+| 4 | Startup config: supervisord.conf + entrypoint.sh | <1 MB |
+| **Total** | | **~1.4 GB** |
 
 **Process management (supervisord):**
 
-| Process | Role | Port |
-|---------|------|------|
-| Xvnc | Virtual framebuffer + VNC server | DISPLAY :1 / 5901 (container-internal) |
-| XFCE4 | Desktop environment | — |
-| noVNC + websockify | VNC → WebSocket proxy | 6901 (host-mapped) |
-| OpenClaw Gateway | Core AI service (manual start) | 18789 (host-mapped) |
+| Process | Role | User | Port | Autostart |
+|---------|------|------|------|-----------|
+| xvnc | VNC server + X11 framebuffer | node | 5901 (internal) | yes |
+| xfce4 | Desktop environment | node | — | yes |
+| novnc | VNC → WebSocket proxy | node | 6901 (host-mapped) | yes |
+| openclaw | Gateway (started after configuration) | node | 18789 (internal) | conditional |
+| gateway-bridge | TCP proxy 18789 → 18790 on 0.0.0.0 | node | 18790 (host-mapped) | conditional |
 
-**entrypoint.sh responsibilities:**
-1. Initialize VNC password (from env var or use default)
-2. Create `.vnc` and `.openclaw` directories, set ownership to `node`
-3. Start supervisord
+**entrypoint.sh:** Creates `.vnc` and `.openclaw` directories, sets VNC password if `$VNC_PASSWORD` is provided, auto-starts OpenClaw if `.configured` marker exists, then launches supervisord.
 
-**Estimated image size:**
-- Base system + XFCE + VNC/noVNC: ~800 MB
-- Node.js 22 + OpenClaw: ~300 MB
-- Playwright Chromium: ~300 MB
-- **Total: ~1.4 GB**
+### 3.4 Asset Management
 
-### 3.3 Port Allocation
+Assets are shared resources that can be assigned to instances.
 
-The CLI maintains a port allocator to avoid conflicts:
+**Model assets:** LLM provider configuration (provider, API key, model name). Supports Anthropic, OpenAI, Google, DeepSeek with preset models. API keys are validated before saving via provider-specific test endpoints. **Models are shared** — multiple instances can use the same model simultaneously.
+
+**Channel assets:** Messaging platform configuration (Telegram bot token, Discord bot token, Slack webhook, Lark App ID + Secret). Credentials are validated before saving. **Channels are exclusive** — each channel can only be assigned to one instance at a time.
+
+**Character assets:** Persona definition (name, role, personality, backstory, quirks, constraints). Rendered into `SOUL.md` Markdown and written to the instance's `~/.openclaw/SOUL.md`. The Gateway hot-reloads this file on change.
+
+### 3.5 Instance Configuration
+
+When a user clicks "Configure" on an instance in the Dashboard, the system applies a multi-step configuration sequence via `docker exec`:
+
+1. Set model provider and API key (`openclaw config set`)
+2. Set model name
+3. Set DM and group policies to "open" and allow all senders
+4. Write channel configuration
+5. Render and write `SOUL.md` (character + roster)
+6. Write `.configured` marker
+7. Start/restart the OpenClaw Gateway process
+
+Configuration status is tracked and reported to the frontend in real-time.
+
+### 3.6 Roster System
+
+The Roster enables bot-to-bot collaboration by injecting team metadata into each instance's `SOUL.md`. Each bot knows who is on the team, what their role is, and when to @mention them.
+
+**Rendering:** When configuring an instance, ClawFleet collects all configured instances' character data, builds a `## Your Team` section with each teammate's name, role, channel, and a one-line description, then appends it to SOUL.md.
+
+**Design principles (prompt-as-code):**
+- Explicit judgment criteria: when to @mention a teammate
+- Negative constraints: when NOT to mention (e.g., don't mention yourself)
+- Dense, scannable format: one line per teammate, not full lore dumps
+
+### 3.7 Skill Management
+
+- **Bundled skills (52):** Ship with OpenClaw. Status depends on binary/environment requirements.
+- **Managed skills:** Installed via `npx clawhub` to `~/.openclaw/skills/`.
+- The Dashboard provides search (via ClawHub API), install, and uninstall operations.
+- ClawHub has rate limits (~20 requests/minute) — errors are handled gracefully.
+
+### 3.8 Snapshot System (Soul Archival)
+
+Snapshots capture an instance's OpenClaw data directory for later reuse:
+
+- **Save:** Copies `~/.clawfleet/data/<name>/openclaw/` to `~/.clawfleet/snapshots/<id>/`, stripping `channels/` and `sessions/` (sensitive/ephemeral data).
+- **Load:** A snapshot can be restored into a new instance.
+- **Metadata:** Name, source instance, creation timestamp stored in `state.json`.
+
+### 3.9 Port Allocation
+
+Sequential allocation from configured base ports:
 
 ```
-Instance   noVNC port   Gateway port
-claw-1  6901         18789
-claw-2  6902         18790
-claw-3  6903         18791
-...
-claw-N  6900+N       18788+N
+Instance   noVNC    Gateway (internal)   Gateway LAN bridge
+claw-1     6901     18789                18789+1=18790 (→ 0.0.0.0)
+claw-2     6902     18790                18791
+claw-N     6900+N   18788+N              18789+N
 ```
 
-Allocation logic:
-- Start from the configured base port, increment until a free port is found
-- Probe availability via `net.Listen` before allocation
-- Allocated ports are recorded in the state file
+Ports are probed via `net.Listen` before allocation to avoid conflicts.
 
-### 3.4 State Management
+### 3.10 State Management
 
-**State file:** `~/.clawfleet/state.json`
+**State file:** `~/.clawfleet/state.json` — metadata cache for instances, assets, and snapshots. Docker is the source of truth for container status; the CLI reconciles on every operation.
 
 ```json
 {
-  "instances": [
-    {
-      "name": "claw-1",
-      "container_id": "abc123...",
-      "status": "running",
-      "ports": {
-        "novnc": 6901,
-        "gateway": 18789
-      },
-      "created_at": "2026-03-07T10:00:00Z"
-    }
-  ]
+  "instances": [{
+    "name": "claw-1",
+    "container_id": "abc123...",
+    "status": "running",
+    "ports": { "novnc": 6901, "gateway": 18789 },
+    "created_at": "2026-03-30T10:00:00Z",
+    "model_asset_id": "anthropic-1",
+    "channel_asset_id": "telegram-1",
+    "character_asset_id": "alice-1"
+  }],
+  "model_assets": [...],
+  "channel_assets": [...],
+  "character_assets": [...],
+  "snapshots": [...]
 }
 ```
 
-The state file is a metadata cache. Docker is the source of truth — the CLI reconciles against the Docker API on every operation.
-
-### 3.5 Data Volumes
-
-Each container gets its own bind-mounted host directory for persistence and isolation:
+### 3.11 Data Volumes
 
 ```
-~/.clawfleet/data/
-├── claw-1/
-│   └── openclaw/     → /home/node/.openclaw inside container
-├── claw-2/
-│   └── openclaw/     → /home/node/.openclaw inside container
-└── claw-3/
-    └── openclaw/     → /home/node/.openclaw inside container
+~/.clawfleet/
+├── config.yaml              # User configuration
+├── state.json               # Instance + asset metadata
+├── serve.pid                # Dashboard daemon PID
+├── logs/                    # Dashboard logs
+├── data/                    # Per-instance data
+│   ├── claw-1/
+│   │   └── openclaw/        → /home/node/.openclaw in container
+│   │       ├── SOUL.md      # Character prompt
+│   │       ├── openclaw.json
+│   │       ├── skills/
+│   │       ├── knowledge/
+│   │       └── sessions/
+│   └── claw-N/
+└── snapshots/               # Saved souls
+    └── <id>/
+        └── openclaw/
 ```
 
-- Data is preserved by default when a container is destroyed
-- `clawfleet destroy --purge` removes the data directory as well
-- Directories are owned by uid 1000 (`node` user), matching the container's user
+Data persists across container restarts. `clawfleet destroy --purge` removes it.
 
-### 3.6 Network Design
+### 3.12 Network Design
 
-**Docker network:**
-- A dedicated bridge network `clawfleet-net` is created on first use
-- Containers can reach each other by name (reserved for future inter-claw communication)
-- Only the noVNC and Gateway ports are bound to the host
+- Bridge network `clawfleet-net` created on first use
+- Containers can reach each other by name (used for inter-instance communication)
+- noVNC port bound to host for desktop access
+- Gateway LAN bridge port (`18790`) bound to `0.0.0.0` for console proxy access
 
-```
-clawfleet-net (bridge)
-├── claw-1 (172.20.0.2)
-├── claw-2 (172.20.0.3)
-└── claw-3 (172.20.0.4)
-```
+## 4. Installation & Deployment
 
-**Host access:**
-- noVNC: `http://localhost:6901` → claw-1 desktop
-- Gateway: accessible at `http://127.0.0.1:18789` from inside the container's Chromium (loopback — not directly exposed to the host user)
-
-## 4. User Workflows
-
-### 4.1 First-time setup
+### 4.1 One-Line Install
 
 ```bash
-# 1. Build the Docker image (once, ~1.4 GB)
-clawfleet build
-
-# 2. Create 3 claws
-clawfleet create 3
-# Output:
-#   Creating claw-1 ... ✓  desktop: http://localhost:6901
-#   Creating claw-2 ... ✓  desktop: http://localhost:6902
-#   Creating claw-3 ... ✓  desktop: http://localhost:6903
-
-# 3. Open a claw's desktop and complete one-time onboarding
-clawfleet desktop claw-1
+curl -fsSL https://raw.githubusercontent.com/clawfleet/ClawFleet/main/scripts/install.sh | sh
 ```
 
-### 4.2 Daily use
+**What it does:**
+1. Detects OS (macOS/Linux) and architecture (amd64/arm64)
+2. Ensures Docker is installed (Colima on macOS, Docker Engine on Linux)
+3. Downloads the latest CLI binary from GitHub Releases (with checksum verification)
+4. Pulls the pre-built Docker image from GHCR (~1.4 GB)
+5. Starts the Dashboard as a background daemon
+6. Opens the browser to `http://localhost:8080`
 
-```bash
-clawfleet list
-# NAME        STATUS    DESKTOP              UPTIME
-# claw-1   running   http://localhost:6901 2d 3h
-# claw-2   running   http://localhost:6902 2d 3h
-# claw-3   stopped   -                    -
+**Options:** `--version <tag>`, `--skip-pull`, `--no-daemon`
 
-clawfleet start claw-3
-clawfleet stop claw-1
-clawfleet logs claw-1
+### 4.2 Daemon Management
+
+The Dashboard runs as a background daemon, managed per platform:
+
+| Platform | Manager | Mechanism |
+|----------|---------|-----------|
+| macOS | launchd | `~/Library/LaunchAgents/com.clawfleet.dashboard.plist` |
+| Linux (non-root) | systemd user service | `~/.config/systemd/user/clawfleet-dashboard.service` |
+| Linux (root) | systemd system service | `/etc/systemd/system/clawfleet-dashboard.service` |
+| Fallback | PID file | `~/.clawfleet/serve.pid` |
+
+**Default bind address:** `127.0.0.1` on macOS (local only), `0.0.0.0` on Linux (remote access).
+
+## 5. Version Management
+
+### 5.1 ClawFleet Version
+
+A single `git tag` locks both the CLI binary and Docker image to the same version.
+
+```
+git tag v0.4.0 && git push origin v0.4.0
+        │
+        ▼
+   GitHub Actions (release.yml)
+   ┌──────────────────────┬────────────────────────────────┐
+   │  release job          │  docker job                     │
+   │  GoReleaser           │  docker/build-push-action       │
+   │  CLI binaries × 4     │  ghcr.io image (multi-arch)     │
+   │  (darwin/linux         │  :v0.4.0 + :latest             │
+   │   × amd64/arm64)      │                                 │
+   └──────────┬────────────┴───────────────┬────────────────┘
+              ▼                            ▼
+       GitHub Release              ghcr.io/clawfleet/clawfleet
 ```
 
-### 4.3 OpenClaw onboarding (inside the container)
+**Version package (`internal/version/`):** `Version`, `GitCommit`, `BuildDate` injected via ldflags. `ImageTag()` derives the Docker image tag — release builds (e.g., `v0.4.0`) use the version tag, dev builds fall back to `latest`.
 
-After opening the noVNC desktop, open the terminal and run:
+### 5.2 OpenClaw Version Locking
 
-```bash
-# Step 1: Run the setup wizard (configure LLM API key, Telegram bot, etc.)
-openclaw onboard --flow quickstart
+The OpenClaw version inside the Docker image is controlled, not left to npm `@latest` at build time.
 
-# Step 2: Start the Gateway
-openclaw gateway --port 18789
+**Single source of truth:** `internal/version/version.go`
+
+```go
+const RecommendedOpenClawVersion = "2026.3.23-2"
 ```
 
-Once the Gateway is running, open Chromium on the desktop and navigate to the URL printed in the terminal (e.g. `http://127.0.0.1:18789/#token=...`) to access the OpenClaw Control UI.
+**How it flows through the system:**
 
-**Future automation (not in v1):** ClawSandbox CLI will automate onboarding — users will only need to supply an API key and Telegram bot token, with no manual desktop interaction required.
+```
+version.go: RecommendedOpenClawVersion = "2026.3.23-2"
+        │
+        ├──→ CI (release.yml)
+        │    Extracted via: grep 'RecommendedOpenClawVersion =' version.go
+        │    Passed as: OPENCLAW_VERSION build-arg to Docker build
+        │    Result: Pre-built GHCR image contains openclaw@2026.3.23-2
+        │
+        ├──→ Dashboard → Build (local)
+        │    Version selector defaults to RecommendedOpenClawVersion
+        │    User can override to any version from npm registry
+        │
+        └──→ Dashboard → Pull
+             Pulls the pre-built GHCR image (version already baked in by CI)
+```
 
-## 5. Resource Budget
+**User experience by path:**
+
+| Path | OpenClaw Version | Determined By |
+|------|-----------------|---------------|
+| `install.sh` (one-line install) | `RecommendedOpenClawVersion` | CI build-arg ← `version.go` |
+| Dashboard → Pull | Same as above | Same pre-built image |
+| Dashboard → Build (local) | User's choice (default: recommended) | Version selector in UI |
+
+**Upgrade workflow:** When a new OpenClaw version is tested and validated, update `RecommendedOpenClawVersion` in `version.go`, cut a new ClawFleet release. The next `install.sh` run or Dashboard Pull will deliver the new version.
+
+### 5.3 Image Naming and Tagging
+
+- **Registry:** `ghcr.io/clawfleet/clawfleet`
+- **Tags:** `:<version>` (e.g., `:v0.4.0`) + `:latest`
+- **Default tag at runtime:** Determined by `version.ImageTag()` — release builds use the version tag, dev builds use `latest`
+
+### 5.4 Auto-Pull on Create
+
+When `clawfleet create` or the Dashboard's create API finds the image missing locally, it automatically attempts `docker pull` from GHCR before failing.
+
+## 6. Resource Budget
 
 Tested on M4 MacBook Air (16 GB RAM, 512 GB SSD):
 
@@ -299,227 +369,200 @@ Tested on M4 MacBook Air (16 GB RAM, 512 GB SSD):
 **Recommendations:**
 - 16 GB host: up to 3 active instances (with Chromium), or 5 light-load instances
 - Default `memory_limit=4g` per container prevents a single runaway instance from affecting the host
-- Adjust limits via `~/.clawfleet/config.yaml`
+- Adjust via `~/.clawfleet/config.yaml`
 
-## 6. Repository Structure
+## 7. Repository Structure
 
 ```
-ClawSandbox/
-├── cmd/
-│   └── clawsandbox/
-│       └── main.go
+ClawFleet/
+├── cmd/clawfleet/              # Binary entry point
+│   └── main.go
 ├── internal/
-│   ├── cli/
-│   │   ├── root.go
-│   │   ├── build.go
-│   │   ├── create.go
-│   │   ├── list.go
-│   │   ├── start.go
-│   │   ├── stop.go
-│   │   ├── destroy.go
-│   │   ├── desktop.go
-│   │   ├── logs.go
-│   │   └── helpers.go
-│   ├── container/
-│   │   ├── client.go
-│   │   ├── manager.go
-│   │   ├── image.go
-│   │   └── network.go
-│   ├── port/
+│   ├── cli/                    # Cobra commands (24 files)
+│   │   ├── root.go             # Root command, registers subcommands
+│   │   ├── create.go           # Instance creation
+│   │   ├── list.go             # Fleet listing
+│   │   ├── start/stop/restart/destroy.go
+│   │   ├── desktop.go          # Open noVNC in browser
+│   │   ├── logs.go             # Container log viewer
+│   │   ├── configure.go        # Interactive configuration wizard
+│   │   ├── dashboard*.go       # Dashboard serve/start/stop/restart/status
+│   │   ├── daemon*.go          # Platform-specific daemon management
+│   │   ├── snapshot*.go        # Snapshot save/list/delete
+│   │   ├── build.go            # Image build command
+│   │   ├── config_show.go      # Show config file
+│   │   └── version.go          # Version display
+│   ├── container/              # Docker orchestration (8 files)
+│   │   ├── client.go           # Docker client init
+│   │   ├── manager.go          # Container lifecycle
+│   │   ├── image.go            # Image build/pull/check/tag
+│   │   ├── configure.go        # Multi-step OpenClaw configuration
+│   │   ├── network.go          # Docker network management
+│   │   ├── skills.go           # Skill install/uninstall
+│   │   └── stats.go            # Resource stats collection
+│   ├── port/                   # Port allocator
 │   │   └── allocator.go
-│   ├── state/
-│   │   └── store.go
-│   ├── config/
+│   ├── state/                  # JSON state persistence
+│   │   ├── store.go            # Instance metadata
+│   │   ├── assets.go           # Model/channel/character assets
+│   │   └── snapshots.go        # Snapshot metadata
+│   ├── config/                 # YAML config loader
 │   │   └── config.go
-│   └── assets/
-│       ├── embed.go
-│       └── docker/
-│           ├── Dockerfile
-│           ├── supervisord.conf
-│           └── entrypoint.sh
+│   ├── assets/                 # Embedded Docker build context
+│   │   ├── embed.go
+│   │   └── docker/
+│   │       ├── Dockerfile
+│   │       ├── supervisord.conf
+│   │       └── entrypoint.sh
+│   ├── snapshot/               # Soul archival logic
+│   │   └── snapshot.go
+│   ├── version/                # Build version info
+│   │   └── version.go          # Version + RecommendedOpenClawVersion
+│   └── web/                    # Web Dashboard (15+ files)
+│       ├── server.go           # HTTP server + PID management
+│       ├── routes.go           # Route registration
+│       ├── embed.go            # Frontend asset embedding
+│       ├── handlers.go         # Instance lifecycle handlers
+│       ├── handlers_assets.go  # Asset CRUD
+│       ├── handlers_configure.go  # Configuration endpoint
+│       ├── handlers_image.go   # Image build/pull/versions
+│       ├── handlers_skills.go  # Skill management
+│       ├── handlers_snapshots.go  # Snapshot CRUD
+│       ├── handlers_console.go # Console proxy (reverse proxy to noVNC)
+│       ├── events.go           # Event bus for real-time updates
+│       ├── ws_stats.go         # WebSocket: resource stats
+│       ├── ws_logs.go          # WebSocket: container logs
+│       ├── ws_events.go        # WebSocket: lifecycle events
+│       ├── validate.go         # LLM/channel credential validation
+│       └── static/             # Embedded frontend
+│           ├── index.html
+│           ├── css/style.css
+│           └── js/
+│               ├── app.js      # Main Preact app
+│               ├── api.js      # REST client
+│               ├── ws.js       # WebSocket manager
+│               ├── i18n.js     # Internationalization
+│               └── components/ # 21 Preact components
+├── scripts/
+│   ├── install.sh              # One-liner install script
+│   └── ensure-go.sh            # Go version bootstrap
 ├── docs/
-│   ├── SYSTEM_DESIGN.md         # English (primary)
-│   └── SYSTEM_DESIGN.zh-CN.md   # Chinese
-├── go.mod
-├── go.sum
-├── Makefile
-├── README.md
-├── README.zh-CN.md
-└── CLAUDE.md
+│   ├── SYSTEM_DESIGN.md
+│   ├── SYSTEM_DESIGN.zh-CN.md
+│   └── images/                 # Screenshots
+├── growth/                     # Marketing materials
+├── .github/workflows/
+│   └── release.yml             # CI/CD pipeline
+├── .goreleaser.yml             # Multi-platform release config
+├── Makefile                    # Build targets
+├── CLAUDE.md                   # AI assistant guide
+├── ROADMAP.md                  # Product roadmap
+├── README.md / README.zh-CN.md
+└── LICENSE                     # MIT
 ```
 
-## 7. Dependencies
+## 8. Dependencies
 
-### Host (ClawSandbox CLI)
+### Host
 | Dependency | Purpose |
 |------------|---------|
 | Go 1.25+ | Compile the CLI |
-| Docker Engine | Container runtime (Docker Desktop for Mac or colima) |
+| Docker Engine | Container runtime (Colima on macOS, Docker Engine on Linux) |
 
 ### Inside each container
 | Dependency | Version | Purpose |
 |------------|---------|---------|
 | Debian Bookworm | 12 | Base OS |
 | Node.js | 22 | OpenClaw runtime |
-| OpenClaw | latest | AI assistant core |
+| OpenClaw | Locked per release | AI assistant core |
 | Chromium (Playwright) | — | Browser automation |
 | XFCE4 | 4.18 | Lightweight desktop |
 | TigerVNC | — | VNC server |
 | noVNC + websockify | — | Browser-accessible VNC client |
-| supervisord | — | Multi-process management inside container |
+| supervisord | — | Multi-process management |
 
 ### Go modules
 | Module | Purpose |
 |--------|---------|
 | `github.com/spf13/cobra` | CLI framework |
 | `github.com/fsouza/go-dockerclient` | Docker Engine API |
+| `github.com/gorilla/websocket` | WebSocket support |
 | `gopkg.in/yaml.v3` | Config file parsing |
 
-## 8. UI Evolution Strategy
+## 9. CI/CD Pipeline
 
-The project uses a phased delivery approach — validate the core before polishing the experience.
+**Trigger:** Push tag matching `v*` (e.g., `v0.4.0`)
 
-### Phase 1: CLI (current)
-All operations via the command line. Goal: a fully functional, production-usable CLI tool.
+**Jobs (parallel):**
 
-### Phase 2: Web UI (before public release)
-After the CLI is stable, add a Web UI for non-technical users:
+| Job | Tool | Output |
+|-----|------|--------|
+| `release` | GoReleaser | 4 CLI binaries (darwin/linux × amd64/arm64) → GitHub Release with checksums |
+| `docker` | docker/build-push-action | Multi-arch image (linux/amd64 + linux/arm64) → GHCR with version tag + `:latest` |
 
-- **Fleet management panel**: a web server on the host provides a unified overview page (create/start/stop/destroy instances, view status)
-- **Instance configuration**: each claw gets its own settings page (LLM provider, Telegram bot, model selection) — no desktop terminal needed for onboarding
-- **Desktop access**: embedded or linked noVNC view per instance
+The `docker` job extracts `RecommendedOpenClawVersion` from `internal/version/version.go` and passes it as the `OPENCLAW_VERSION` build-arg, ensuring the pre-built image contains the tested OpenClaw version.
 
-The CLI is always kept as the primary interface for advanced users and automation.
+**Release workflow:**
 
-## 9. Scope
+```bash
+# 1. Update RecommendedOpenClawVersion if needed
+# 2. Tag and push
+git tag v0.5.0
+git push origin v0.5.0
+# CI handles: binary builds, image build+push, GitHub Release creation
+```
 
-### Phase 1 MVP (CLI)
+## 10. Configuration
 
-- [x] Docker image build (Dockerfile + supervisord + entrypoint)
-- [x] `build` — build the Docker image
-- [x] `create N` — create N container instances
-- [x] `list` — list all instances with live status from Docker
-- [x] `start` / `stop` — start and stop instances
-- [x] `destroy [--purge]` — destroy instances, optionally purging data
-- [x] `desktop` — open noVNC desktop in browser
-- [x] `logs [-f]` — tail instance logs
-- [x] Automatic port allocation with conflict detection
-- [x] Per-instance data volume persistence
+**File:** `~/.clawfleet/config.yaml`
 
-### Phase 2 (Web UI)
-- [ ] Fleet management panel (web server)
-- [ ] Per-instance configuration pages (LLM / Telegram / etc.)
-- [ ] Automated OpenClaw onboarding
+```yaml
+image:
+  name: "ghcr.io/clawfleet/clawfleet"
+  tag: "v0.4.0"             # Determined by version.ImageTag()
 
-**Out of scope (future):**
-- Inter-claw group chat and task delegation
-- Instance templates / preset configurations
-- Remote host support
+ports:
+  novnc_start: 6901         # Sequential: 6901, 6902, ...
+  gateway_start: 18789      # Sequential: 18789, 18790, ...
 
-## 10. Validation
+resources:
+  memory_limit: "4g"        # Per-container
+  cpu_limit: 2.0            # Per-container (cores)
+
+naming:
+  prefix: "claw"            # Instance names: claw-1, claw-2, ...
+```
+
+## 11. Validation
+
+### End-to-end (one-line install)
+```bash
+# Fresh machine
+curl -fsSL https://raw.githubusercontent.com/clawfleet/ClawFleet/main/scripts/install.sh | sh
+# → Docker installed, CLI downloaded, image pulled, Dashboard running at :8080
+
+# Verify OpenClaw version inside the image
+docker exec claw-1 npm list -g openclaw
+# → Should show RecommendedOpenClawVersion
+```
 
 ### Build validation
 ```bash
-make build
-clawfleet build
+make build && make test
 ```
 
-### End-to-end validation
+### Manual lifecycle
 ```bash
-# 1. Create 2 instances
 clawfleet create 2
-
-# 2. Confirm containers are running
 clawfleet list
-
-# 3. Open desktop
-clawfleet desktop claw-1
-# → Browser opens http://localhost:6901 showing XFCE desktop
-
-# 4. Complete onboarding inside the container
-openclaw onboard --flow quickstart
-openclaw gateway --port 18789
-# → Open Chromium, navigate to printed URL, confirm Control UI loads
-
-# 5. Stop / start (verify data persistence)
 clawfleet stop claw-1
 clawfleet start claw-1
-# → ~/.openclaw data survives container restart
-
-# 6. Destroy
+# → Data persists across restarts
 clawfleet destroy claw-2
-clawfleet list
-# → claw-2 no longer listed
 ```
 
 ### Resource validation
 ```bash
 docker stats claw-1 claw-2
-# → Confirm memory stays within memory_limit
-```
-
-## 11. Version Management
-
-A single `git tag` locks both the CLI binary and Docker image to the same version, with automated publishing to GitHub Release and GHCR.
-
-### Architecture
-
-```
-git tag v0.1.0 && git push origin v0.1.0
-        │
-        ▼
-   GitHub Actions
-   ┌──────────────────┬──────────────────────┐
-   │  GoReleaser       │  Docker Build+Push    │
-   │  CLI binaries x4  │  ghcr.io image        │
-   │  (darwin/linux    │  :0.1.0 + :latest     │
-   │   x amd64/arm64) │                        │
-   └────────┬─────────┴──────────┬─────────────┘
-            ▼                    ▼
-     GitHub Release         ghcr.io/clawfleet/clawfleet
-```
-
-### Shared version package (`internal/version/`)
-
-Version metadata (`Version`, `GitCommit`, `BuildDate`) is injected at build time via ldflags into `internal/version`. Both `internal/cli/version.go` and `internal/config/config.go` import from this shared package.
-
-The `ImageTag()` helper derives the Docker image tag from the CLI version:
-- Release build (e.g. `v0.1.0`): returns `0.1.0`
-- Dev build (no tag): returns `latest`
-
-### Image naming and tagging
-
-- **Registry**: `ghcr.io/clawfleet/clawfleet`
-- **Default tag**: determined at runtime via `version.ImageTag()`
-- `clawfleet build` tags the image with both `:<version>` and `:latest`
-- `clawfleet create` uses `:<version>` to ensure CLI-image version consistency
-
-### Auto-pull on create
-
-When `clawfleet create` (or the Dashboard's create action) finds the image missing locally, it automatically attempts `docker pull` from GHCR before failing. Users with internet access never need to run `clawfleet build`.
-
-```
-image not found locally
-  → docker pull ghcr.io/clawfleet/clawfleet:0.1.0
-  → success? proceed with create
-  → fail? suggest `clawfleet build`
-```
-
-### CI pipeline (`.github/workflows/release.yml`)
-
-Triggered on `v*` tag push. Two parallel jobs:
-
-| Job | Tool | Output |
-|-----|------|--------|
-| `release` | GoReleaser | 4 CLI binaries → GitHub Release |
-| `docker` | docker/build-push-action | Image → `ghcr.io/clawfleet/clawfleet:<version>` + `:latest` |
-
-### Release workflow (for maintainers)
-
-```bash
-git checkout main
-git pull origin main
-git tag v0.1.0
-git push origin v0.1.0
-# CI handles the rest
+# → Memory within memory_limit
 ```

--- a/docs/SYSTEM_DESIGN.zh-CN.md
+++ b/docs/SYSTEM_DESIGN.zh-CN.md
@@ -1,7 +1,6 @@
-# ClawSandbox 系统设计文档
+# ClawFleet 系统设计文档
 
-> 版本: v0.1 (Draft)
-> 日期: 2026-03-07
+> 版本: v0.4 | 日期: 2026-03-30
 
 [English](./SYSTEM_DESIGN.md)
 
@@ -9,529 +8,561 @@
 
 ## 1. 概述
 
-ClawSandbox 是一个 CLI 工具，在单台宿主机上批量创建和管理多个隔离的 OpenClaw 实例。每个实例运行在独立的 Docker 容器中，拥有完整的 Linux 桌面环境，用户可通过浏览器访问桌面、通过 Telegram 与各实例独立对话。
+ClawFleet 在单台机器上部署和管理多个隔离的 OpenClaw 实例，通过浏览器 Dashboard 完成全部操作。每个实例运行在独立的 Docker 容器中，拥有完整的 Linux 桌面（XFCE4 + TigerVNC + noVNC），用户可通过浏览器访问。用户可在 Dashboard 或 CLI 中管理军团——创建实例、配置 LLM 供应商、分配消息渠道、定义角色人设、监控资源。
 
-## 2. 系统架构
+## 2. 架构分层
+
+ClawFleet 构建于 ClawSandbox 之上，后者是专为容器编排和实例生命周期管理打造的基础设施层。
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                      宿主机 (macOS / Linux)                  │
-│                                                             │
-│  ┌───────────────────────────────────┐                      │
-│  │        ClawSandbox CLI (Go)       │                      │
-│  │  ┌─────────┬──────────┬────────┐  │                      │
-│  │  │ create  │  list    │ desktop│  │                      │
-│  │  │ start   │  stop    │destroy │  │                      │
-│  │  └─────────┴──────────┴────────┘  │                      │
-│  │  ┌─────────────────────────────┐  │                      │
-│  │  │   Docker Engine SDK (Go)    │  │                      │
-│  │  └──────────────┬──────────────┘  │                      │
-│  │                 │                 │                      │
-│  │  ┌──────────────┴──────────────┐  │                      │
-│  │  │     Port Allocator          │  │                      │
-│  │  │  noVNC: 6901, 6902, ...     │  │                      │
-│  │  │  Gateway: 18789, 18790, ... │  │                      │
-│  │  └─────────────────────────────┘  │                      │
-│  │  ┌─────────────────────────────┐  │                      │
-│  │  │     Instance State Store    │  │                      │
-│  │  │  ~/.clawfleet/state.json  │  │                      │
-│  │  └─────────────────────────────┘  │                      │
-│  └───────────────────────────────────┘                      │
-│                     │ Docker API                            │
-│    ┌────────────────┼────────────────────────┐              │
-│    │                │                        │              │
-│    ▼                ▼                        ▼              │
-│  ┌──────────┐  ┌──────────┐           ┌──────────┐         │
-│  │claw-1 │  │claw-2 │    ...    │claw-N │         │
-│  │          │  │          │           │          │         │
-│  │ XFCE     │  │ XFCE     │           │ XFCE     │         │
-│  │ noVNC    │  │ noVNC    │           │ noVNC    │         │
-│  │ Node≥22  │  │ Node≥22  │           │ Node≥22  │         │
-│  │ Chromium │  │ Chromium │           │ Chromium │         │
-│  │ OpenClaw │  │ OpenClaw │           │ OpenClaw │         │
-│  │ Gateway  │  │ Gateway  │           │ Gateway  │         │
-│  └──────────┘  └──────────┘           └──────────┘         │
-│   :6901/:18789  :6902/:18790           :690N/:1878(8+N)    │
+│                   浏览器 (Dashboard UI)                       │
+│              Preact SPA @ http://localhost:8080              │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ REST API + WebSocket
+┌──────────────────────────▼──────────────────────────────────┐
+│                  ClawFleet（产品层）                           │
+│  internal/web/ + internal/cli/                               │
+│  REST API、WebSocket 流、资产管理、技能、                       │
+│  i18n、花名册、快照、daemon 管理                                │
+├─────────────────────────────────────────────────────────────┤
+│                ClawSandbox（基础设施层）                       │
+│  internal/container/、/state/、/port/、/config/、             │
+│  /assets/、/snapshot/、/version/                              │
+│  Docker 编排、状态持久化、端口分配                               │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ Docker API (go-dockerclient)
+┌──────────────────────────▼──────────────────────────────────┐
+│                      Docker Engine                           │
+│  ┌──────────┐  ┌──────────┐           ┌──────────┐          │
+│  │ claw-1   │  │ claw-2   │    ...    │ claw-N   │          │
+│  │ XFCE4    │  │ XFCE4    │           │ XFCE4    │          │
+│  │ noVNC    │  │ noVNC    │           │ noVNC    │          │
+│  │ OpenClaw │  │ OpenClaw │           │ OpenClaw │          │
+│  │ Gateway  │  │ Gateway  │           │ Gateway  │          │
+│  └──────────┘  └──────────┘           └──────────┘          │
+│   :6901/:18789  :6902/:18790           :690N/:1878(8+N)     │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-## 3. 组件详细设计
+**依赖规则：** ClawFleet → ClawSandbox（严格单向，不可反向依赖）。
 
-### 3.1 ClawSandbox CLI
+## 3. 组件设计
 
-**技术栈：**
-- 语言：Go 1.25+
-- CLI 框架：[cobra](https://github.com/spf13/cobra)
-- Docker 交互：[go-dockerclient](https://github.com/fsouza/go-dockerclient)
-- 编译产物：单个静态链接二进制文件（darwin/arm64, darwin/amd64, linux/amd64, linux/arm64）
+### 3.1 CLI
 
-**命令设计：**
+**技术栈：** Go 1.25+、Cobra、go-dockerclient。单个静态链接二进制文件，支持 darwin/linux × amd64/arm64。
 
-```
-clawfleet build                       # 构建 Docker 镜像
-clawfleet create <N>                  # 创建 N 个龙虾实例
-clawfleet list                        # 列出所有实例及状态
-clawfleet start <name|all>            # 启动实例
-clawfleet stop <name|all>             # 停止实例
-clawfleet destroy <name|all>          # 销毁实例（默认保留数据）
-clawfleet destroy --purge <name|all>  # 销毁实例并删除数据
-clawfleet desktop <name>              # 在浏览器中打开该实例的 noVNC 桌面
-clawfleet logs <name> [-f]            # 查看实例日志
-```
+**命令：**
 
-**配置文件：** `~/.clawfleet/config.yaml`
-
-```yaml
-# 基础镜像配置
-image:
-  name: "ghcr.io/clawfleet/clawfleet"
-  tag: "latest"
-
-# 端口范围
-ports:
-  novnc_start: 6901      # noVNC 起始端口，递增分配
-  gateway_start: 18789   # Gateway 起始端口，递增分配
-
-# 容器资源限制
-resources:
-  memory_limit: "4g"     # 每个容器内存上限
-  cpu_limit: "2.0"       # 每个容器 CPU 上限（核数）
-
-# 实例命名前缀
-naming:
-  prefix: "claw"      # 实例名: claw-1, claw-2, ...
-```
-
-### 3.2 Docker 镜像 (ghcr.io/clawfleet/clawfleet)
-
-**基础镜像选择：** `node:22-bookworm`（与 OpenClaw 官方 Docker 方案一致）
-
-**镜像分层设计：**
-
-```dockerfile
-# Layer 1: 基础系统 + 桌面环境
-FROM node:22-bookworm
-
-# 系统依赖 + XFCE 桌面 + VNC/noVNC
-RUN apt-get update && apt-get install -y \
-    xfce4 xfce4-terminal \
-    tigervnc-standalone-server \
-    novnc websockify \
-    dbus-x11 \
-    chromium \
-    fonts-noto-cjk \
-    supervisor curl wget \
-    && rm -rf /var/lib/apt/lists/*
-
-# Chromium --no-sandbox 封装（容器内必需）
-RUN mv /usr/bin/chromium /usr/bin/chromium-real \
-    && printf '#!/bin/sh\nexec /usr/bin/chromium-real --no-sandbox "$@"\n' > /usr/bin/chromium \
-    && chmod +x /usr/bin/chromium
-
-# Layer 2: OpenClaw 安装
-RUN npm install -g openclaw@latest
-
-# Layer 3: Playwright Chromium（构建时安装，避免运行时下载）
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN node /usr/local/lib/node_modules/openclaw/node_modules/playwright-core/cli.js install chromium
-
-# Layer 4: 启动配置
-COPY supervisord.conf /etc/supervisor/supervisord.conf
-COPY entrypoint.sh /entrypoint.sh
-
-EXPOSE 6901 18789
-ENTRYPOINT ["/entrypoint.sh"]
-```
-
-**进程管理 (supervisord)：**
-
-容器内需要同时运行多个进程，使用 supervisord 统一管理：
-
-| 进程 | 作用 | 端口 |
+| 分组 | 命令 | 说明 |
 |------|------|------|
-| Xvnc | 虚拟帧缓冲 + VNC 服务端 | DISPLAY :1 / 5901 (容器内) |
-| XFCE4 | 桌面环境 | — |
-| noVNC + websockify | VNC → WebSocket 代理 | 6901 (映射到宿主) |
-| OpenClaw Gateway | OpenClaw 核心服务（手动启动） | 18789 (映射到宿主) |
+| 军团 | `create <N>` | 创建 N 个实例 |
+| | `list` | 列出所有实例及状态 |
+| | `start <name\|all>` | 启动实例 |
+| | `stop <name\|all>` | 停止实例 |
+| | `restart <name\|all>` | 重启实例 |
+| | `destroy <name\|all> [--purge]` | 销毁实例，可选删除数据 |
+| | `desktop <name>` | 在浏览器中打开 noVNC 桌面 |
+| | `logs <name> [-f]` | 查看/跟踪容器日志 |
+| | `configure <name>` | 交互式配置向导 |
+| Dashboard | `dashboard serve` | 启动 Web 服务（前台） |
+| | `dashboard start [--host --port]` | 以后台 daemon 启动 |
+| | `dashboard stop` | 停止 daemon |
+| | `dashboard restart` | 重启 daemon |
+| | `dashboard status` | 查看 daemon 状态 |
+| 镜像 | `build` | 在本地构建 Docker 镜像 |
+| 快照 | `snapshot save <name>` | 归档实例灵魂 |
+| | `snapshot list` | 列出已保存的灵魂 |
+| | `snapshot delete <name>` | 删除已保存的灵魂 |
+| 系统 | `config` | 显示配置文件 |
+| | `version` | 输出版本信息 |
 
-**entrypoint.sh 职责：**
-1. 初始化 VNC 密码（可由环境变量注入或使用默认值）
-2. 创建 `.vnc` 和 `.openclaw` 目录，设置权限
-3. 启动 supervisord
+### 3.2 Web Dashboard
 
-**预估镜像大小：**
-- 基础系统 + XFCE + VNC/noVNC: ~800MB
-- Node.js 22 + OpenClaw: ~300MB
-- Chromium (Playwright): ~300MB
-- **总计: ~1.4GB**
+内嵌的 Preact SPA，由 Go HTTP 服务在端口 8080 上提供。
 
-### 3.3 端口分配策略
+**REST API（25+ 端点）：**
 
-CLI 维护一个简单的端口分配器，避免冲突：
+| 类别 | 端点 | 用途 |
+|------|------|------|
+| 实例 | `GET/POST /instances`、`POST /{name}/start\|stop`、`DELETE /{name}`、`POST /batch-destroy`、`POST /{name}/configure`、`GET /{name}/configure/status`、`POST /{name}/restart-bot`、`POST /{name}/reset` | 完整实例生命周期 |
+| 资产 | `GET/POST/PUT/DELETE /assets/models`、`/assets/channels`、`/assets/characters`、`POST /assets/models/test`、`POST /assets/channels/test` | 模型、渠道、角色 CRUD + 验证 |
+| 技能 | `GET /{name}/skills`、`POST /{name}/skills/install`、`DELETE /{name}/skills/{slug}`、`GET /skills/search` | 通过 ClawHub 管理技能 |
+| 快照 | `GET/POST/DELETE /snapshots` | 灵魂归档 |
+| 镜像 | `GET /image/status`、`POST /image/build`、`POST /image/pull`、`GET /image/openclaw-versions` | 镜像生命周期 + OpenClaw 版本选择器 |
+
+**WebSocket 流：**
+
+| 端点 | 用途 |
+|------|------|
+| `/ws/stats` | 实时 CPU/内存监控 |
+| `/ws/logs/{name}` | 实时容器日志 |
+| `/ws/events` | 生命周期事件（创建、启动、停止等） |
+
+**控制台代理：** `/console/{name}` 反向代理到实例的 noVNC 桌面，在 Dashboard 内嵌入桌面访问。Gateway LAN bridge（`0.0.0.0:18790`）使代理能够访问 Gateway UI。
+
+**前端组件（21 个）：** toolbar、sidebar、dashboard、instance-card、instance-desktop、create-dialog、configure-dialog、image-page、logs-viewer、model/channel/character 资产页面和对话框、skills、skill-manager-dialog、snapshots、snapshot-dialog、stats-chart、connection-status、toast。
+
+**国际化：** 支持英文和中文，可在工具栏切换。
+
+### 3.3 Docker 镜像
+
+**仓库地址：** `ghcr.io/clawfleet/clawfleet`
+
+**基础镜像：** `node:22-bookworm`
+
+**分层设计：**
+
+| 层 | 内容 | 大小 |
+|---|------|------|
+| 1 | 系统包：XFCE4、TigerVNC、noVNC、Chromium、CJK 字体、supervisord | ~800 MB |
+| 2 | OpenClaw：`npm install -g openclaw@${OPENCLAW_VERSION}` + 飞书扩展 | ~300 MB |
+| 3 | Playwright Chromium：预装在 `/ms-playwright` | ~300 MB |
+| 4 | 启动配置：supervisord.conf + entrypoint.sh | <1 MB |
+| **总计** | | **~1.4 GB** |
+
+**进程管理（supervisord）：**
+
+| 进程 | 作用 | 用户 | 端口 | 自启动 |
+|------|------|------|------|--------|
+| xvnc | VNC 服务 + X11 帧缓冲 | node | 5901（内部） | 是 |
+| xfce4 | 桌面环境 | node | — | 是 |
+| novnc | VNC → WebSocket 代理 | node | 6901（映射到宿主） | 是 |
+| openclaw | Gateway（配置后启动） | node | 18789（内部） | 条件启动 |
+| gateway-bridge | TCP 代理 18789 → 18790（0.0.0.0） | node | 18790（映射到宿主） | 条件启动 |
+
+**entrypoint.sh：** 创建 `.vnc` 和 `.openclaw` 目录，设置 VNC 密码（如提供 `$VNC_PASSWORD`），若存在 `.configured` 标记则自动启动 OpenClaw，然后启动 supervisord。
+
+### 3.4 资产管理
+
+资产是可分配给实例的共享资源。
+
+**模型资产：** LLM 供应商配置（供应商、API Key、模型名）。支持 Anthropic、OpenAI、Google、DeepSeek 预设模型。保存前通过供应商特定的测试端点验证 API Key。**模型是共享的** — 多个实例可同时使用同一模型。
+
+**渠道资产：** 消息平台配置（Telegram bot token、Discord bot token、Slack webhook、Lark App ID + Secret）。保存前验证凭证。**渠道是独占的** — 每个渠道只能分配给一个实例。
+
+**角色资产：** 人设定义（名称、角色、性格、背景、特点、约束）。渲染为 `SOUL.md` Markdown 并写入实例的 `~/.openclaw/SOUL.md`。Gateway 会在文件变更时热加载。
+
+### 3.5 实例配置
+
+用户在 Dashboard 中点击"配置"时，系统通过 `docker exec` 执行多步配置序列：
+
+1. 设置模型供应商和 API Key（`openclaw config set`）
+2. 设置模型名称
+3. 设置 DM 和群组策略为 "open"，允许所有发送者
+4. 写入渠道配置
+5. 渲染并写入 `SOUL.md`（角色 + 花名册）
+6. 写入 `.configured` 标记
+7. 启动/重启 OpenClaw Gateway 进程
+
+配置状态实时跟踪并报告给前端。
+
+### 3.6 花名册系统
+
+花名册通过向每个实例的 `SOUL.md` 注入团队元数据来实现 bot 间协作。每个 bot 知道团队里有谁、角色是什么、什么时候应该 @对方。
+
+**渲染：** 配置实例时，ClawFleet 收集所有已配置实例的角色数据，构建 `## Your Team` 段落，包含每个队友的名称、角色、渠道和一句话描述，然后追加到 SOUL.md。
+
+**设计原则（提示词即代码）：**
+- 明确的判断标准：何时 @队友
+- 否定约束：何时不应该提及（如不要提及自己）
+- 信息密集、易于扫描：每个队友一行，不做长篇叙述
+
+### 3.7 技能管理
+
+- **内置技能（52 个）：** 随 OpenClaw 一起发布。状态取决于二进制/环境依赖。
+- **托管技能：** 通过 `npx clawhub` 安装到 `~/.openclaw/skills/`。
+- Dashboard 提供搜索（通过 ClawHub API）、安装和卸载操作。
+- ClawHub 有速率限制（~20 次/分钟）— 错误会被优雅处理。
+
+### 3.8 快照系统（灵魂归档）
+
+快照捕获实例的 OpenClaw 数据目录以供后续复用：
+
+- **保存：** 将 `~/.clawfleet/data/<name>/openclaw/` 复制到 `~/.clawfleet/snapshots/<id>/`，剥离 `channels/` 和 `sessions/`（敏感/临时数据）。
+- **加载：** 快照可恢复到新实例。
+- **元数据：** 名称、来源实例、创建时间戳存储在 `state.json` 中。
+
+### 3.9 端口分配
+
+从配置的基础端口顺序分配：
 
 ```
-实例       noVNC 端口     Gateway 端口
-claw-1  6901          18789
-claw-2  6902          18790
-claw-3  6903          18791
-...
-claw-N  6900+N        18788+N
+实例       noVNC    Gateway（内部）   Gateway LAN bridge
+claw-1     6901     18789            18790（→ 0.0.0.0）
+claw-2     6902     18790            18791
+claw-N     6900+N   18788+N          18789+N
 ```
 
-分配逻辑：
-- 从配置的起始端口开始递增
-- 创建前检测端口是否被占用（`net.Listen` 探测）
-- 分配结果记录在状态文件中
+分配前通过 `net.Listen` 探测端口可用性，避免冲突。
 
-### 3.4 状态管理
+### 3.10 状态管理
 
-**状态文件：** `~/.clawfleet/state.json`
+**状态文件：** `~/.clawfleet/state.json` — 实例、资产和快照的元数据缓存。容器实际状态以 Docker 为准；CLI 每次操作时与 Docker API 对账。
 
 ```json
 {
-  "instances": [
-    {
-      "name": "claw-1",
-      "container_id": "abc123...",
-      "status": "running",
-      "ports": {
-        "novnc": 6901,
-        "gateway": 18789
-      },
-      "created_at": "2026-03-07T10:00:00Z"
-    }
-  ]
+  "instances": [{
+    "name": "claw-1",
+    "container_id": "abc123...",
+    "status": "running",
+    "ports": { "novnc": 6901, "gateway": 18789 },
+    "created_at": "2026-03-30T10:00:00Z",
+    "model_asset_id": "anthropic-1",
+    "channel_asset_id": "telegram-1",
+    "character_asset_id": "alice-1"
+  }],
+  "model_assets": [...],
+  "channel_assets": [...],
+  "character_assets": [...],
+  "snapshots": [...]
 }
 ```
 
-状态文件是 CLI 的元数据缓存，真实状态以 Docker 容器状态为准。CLI 每次操作时与 Docker API 对账，修正不一致。
-
-### 3.5 数据卷设计
-
-每个容器挂载独立的宿主目录，实现数据持久化和隔离：
+### 3.11 数据卷
 
 ```
-~/.clawfleet/data/
-├── claw-1/
-│   └── openclaw/     → 容器内 /home/node/.openclaw
-├── claw-2/
-│   └── openclaw/     → 容器内 /home/node/.openclaw
-└── claw-3/
-    └── openclaw/     → 容器内 /home/node/.openclaw
+~/.clawfleet/
+├── config.yaml              # 用户配置
+├── state.json               # 实例 + 资产元数据
+├── serve.pid                # Dashboard daemon PID
+├── logs/                    # Dashboard 日志
+├── data/                    # 实例数据（按实例隔离）
+│   ├── claw-1/
+│   │   └── openclaw/        → 容器内 /home/node/.openclaw
+│   │       ├── SOUL.md      # 角色提示词
+│   │       ├── openclaw.json
+│   │       ├── skills/
+│   │       ├── knowledge/
+│   │       └── sessions/
+│   └── claw-N/
+└── snapshots/               # 已保存的灵魂
+    └── <id>/
+        └── openclaw/
 ```
 
-- 容器销毁后数据默认保留在宿主机上
-- `clawfleet destroy --purge` 可同时删除数据
-- 目录权限设为 uid 1000（node 用户），与容器内用户一致
+容器重启后数据保留。`clawfleet destroy --purge` 可同时删除。
 
-### 3.6 网络设计
+### 3.12 网络设计
 
-**Docker 网络：**
-- 创建专用 bridge 网络 `clawfleet-net`
-- 各容器通过容器名互相可达（为后续龙虾间通信预留）
-- 每个容器仅暴露 noVNC 和 Gateway 端口到宿主机
+- Bridge 网络 `clawfleet-net` 在首次使用时创建
+- 容器可通过容器名互相访问（用于实例间通信）
+- noVNC 端口绑定到宿主机，用于桌面访问
+- Gateway LAN bridge 端口（`18790`）绑定到 `0.0.0.0`，用于控制台代理访问
 
-```
-clawfleet-net (bridge)
-├── claw-1 (172.20.0.2)
-├── claw-2 (172.20.0.3)
-└── claw-3 (172.20.0.4)
-```
+## 4. 安装与部署
 
-**宿主机访问：**
-- noVNC: `http://localhost:6901` → claw-1 桌面
-- Gateway: `ws://localhost:18789` → claw-1 Gateway（内部用，用户一般不直接访问）
-
-## 4. 用户操作流程
-
-### 4.1 首次使用
+### 4.1 一键安装
 
 ```bash
-# 1. 构建镜像（首次，约 1.4GB）
-clawfleet build
-
-# 2. 创建 3 个龙虾
-clawfleet create 3
-# → 输出:
-#   Creating claw-1 ... ✓  desktop: http://localhost:6901
-#   Creating claw-2 ... ✓  desktop: http://localhost:6902
-#   Creating claw-3 ... ✓  desktop: http://localhost:6903
-
-# 3. 打开龙虾桌面，进入 OpenClaw onboard 配置 Telegram 等
-clawfleet desktop claw-1
+curl -fsSL https://raw.githubusercontent.com/clawfleet/ClawFleet/main/scripts/install.sh | sh
 ```
 
-### 4.2 日常使用
+**流程：**
+1. 检测 OS（macOS/Linux）和架构（amd64/arm64）
+2. 确保 Docker 已安装（macOS 用 Colima，Linux 用 Docker Engine）
+3. 从 GitHub Releases 下载最新 CLI 二进制文件（含 checksum 校验）
+4. 从 GHCR 拉取预构建 Docker 镜像（~1.4 GB）
+5. 以后台 daemon 启动 Dashboard
+6. 打开浏览器访问 `http://localhost:8080`
 
-```bash
-# 查看军团状态
-clawfleet list
-# NAME        STATUS    DESKTOP              UPTIME
-# claw-1   running   http://localhost:6901 2d 3h
-# claw-2   running   http://localhost:6902 2d 3h
-# claw-3   stopped   -                    -
+**选项：** `--version <tag>`、`--skip-pull`、`--no-daemon`
 
-# 启动/停止
-clawfleet start claw-3
-clawfleet stop claw-1
+### 4.2 Daemon 管理
 
-# 查看日志
-clawfleet logs claw-1
+Dashboard 以后台 daemon 运行，按平台管理：
+
+| 平台 | 管理器 | 机制 |
+|------|--------|------|
+| macOS | launchd | `~/Library/LaunchAgents/com.clawfleet.dashboard.plist` |
+| Linux（非 root） | systemd 用户服务 | `~/.config/systemd/user/clawfleet-dashboard.service` |
+| Linux（root） | systemd 系统服务 | `/etc/systemd/system/clawfleet-dashboard.service` |
+| 回退 | PID 文件 | `~/.clawfleet/serve.pid` |
+
+**默认绑定地址：** macOS 为 `127.0.0.1`（仅本地），Linux 为 `0.0.0.0`（远程访问）。
+
+## 5. 版本管理
+
+### 5.1 ClawFleet 版本
+
+一次 `git tag` 同时锁定 CLI 和 Docker 镜像版本。
+
+```
+git tag v0.4.0 && git push origin v0.4.0
+        │
+        ▼
+   GitHub Actions (release.yml)
+   ┌──────────────────────┬────────────────────────────────┐
+   │  release job          │  docker job                     │
+   │  GoReleaser           │  docker/build-push-action       │
+   │  CLI 二进制 × 4       │  ghcr.io 镜像（多架构）          │
+   │  (darwin/linux         │  :v0.4.0 + :latest             │
+   │   × amd64/arm64)      │                                 │
+   └──────────┬────────────┴───────────────┬────────────────┘
+              ▼                            ▼
+       GitHub Release              ghcr.io/clawfleet/clawfleet
 ```
 
-### 4.3 OpenClaw Onboard 流程（容器内）
+**版本包（`internal/version/`）：** `Version`、`GitCommit`、`BuildDate` 通过 ldflags 注入。`ImageTag()` 推导 Docker 镜像标签——release 构建（如 `v0.4.0`）使用版本标签，dev 构建回退到 `latest`。
 
-用户通过 noVNC 进入桌面后，在终端中执行：
+### 5.2 OpenClaw 版本锁定
 
-```bash
-# 第一步：运行初始化向导（配置 LLM API Key、Telegram Bot 等）
-openclaw onboard --flow quickstart
+Docker 镜像内的 OpenClaw 版本是受控的，不依赖构建时 npm 的 `@latest`。
 
-# 第二步：启动 Gateway
-openclaw gateway --port 18789
+**单一真相源：** `internal/version/version.go`
+
+```go
+const RecommendedOpenClawVersion = "2026.3.23-2"
 ```
 
-Gateway 启动后，在桌面的 Chromium 浏览器中访问终端输出的地址（形如 `http://127.0.0.1:18789/#token=...`），即可打开 OpenClaw 控制台。
+**版本流转：**
 
-**后续优化方向（非第一版）：** 将 onboard 流程通过 ClawSandbox CLI 自动化，用户只需提供 API key 和 Telegram bot token，无需手动进入桌面操作。
+```
+version.go: RecommendedOpenClawVersion = "2026.3.23-2"
+        │
+        ├──→ CI (release.yml)
+        │    提取方式：grep 'RecommendedOpenClawVersion =' version.go
+        │    传递方式：OPENCLAW_VERSION build-arg → Docker 构建
+        │    结果：预构建 GHCR 镜像包含 openclaw@2026.3.23-2
+        │
+        ├──→ Dashboard → Build（本地构建）
+        │    版本选择器默认值 = RecommendedOpenClawVersion
+        │    用户可覆盖为 npm registry 中的任意版本
+        │
+        └──→ Dashboard → Pull
+             拉取预构建 GHCR 镜像（版本已由 CI 内置）
+```
 
-## 5. 资源预算
+**各路径的用户体验：**
 
-基于 M4 MacBook Air (16GB RAM, 512GB SSD) 的测试环境：
+| 路径 | OpenClaw 版本 | 由谁决定 |
+|------|-------------|---------|
+| `install.sh`（一键安装） | `RecommendedOpenClawVersion` | CI build-arg ← `version.go` |
+| Dashboard → Pull | 同上 | 同一个预构建镜像 |
+| Dashboard → Build（本地） | 用户选择（默认推荐版本） | UI 版本选择器 |
+
+**升级流程：** 当新的 OpenClaw 版本经过测试验证后，更新 `version.go` 中的 `RecommendedOpenClawVersion`，发布新的 ClawFleet release。下次 `install.sh` 或 Dashboard Pull 即可获得新版本。
+
+### 5.3 镜像命名与标签
+
+- **仓库地址：** `ghcr.io/clawfleet/clawfleet`
+- **标签：** `:<version>`（如 `:v0.4.0`）+ `:latest`
+- **运行时默认标签：** 由 `version.ImageTag()` 决定——release 构建使用版本标签，dev 构建使用 `latest`
+
+### 5.4 自动拉取镜像
+
+当 `clawfleet create` 或 Dashboard 的创建 API 发现本地缺少镜像时，自动尝试从 GHCR 拉取。
+
+## 6. 资源预算
+
+基于 M4 MacBook Air（16 GB RAM，512 GB SSD）测试：
 
 | 资源 | 单个实例 | 3 个实例 | 5 个实例 |
 |------|---------|---------|---------|
-| 内存（idle） | ~1.5GB | ~4.5GB | ~7.5GB |
-| 内存（Chromium 活跃） | ~3GB | ~9GB | 不建议 |
-| 磁盘（镜像） | 1.4GB（共享） | 1.4GB | 1.4GB |
-| 磁盘（数据卷/实例） | ~200MB | ~600MB | ~1GB |
+| 内存（idle） | ~1.5 GB | ~4.5 GB | ~7.5 GB |
+| 内存（Chromium 活跃） | ~3 GB | ~9 GB | 不建议 |
+| 磁盘（镜像，共享） | 1.4 GB | 1.4 GB | 1.4 GB |
+| 磁盘（数据卷/实例） | ~200 MB | ~600 MB | ~1 GB |
 | CPU（idle） | <0.5 核 | <1.5 核 | <2.5 核 |
 
 **建议：**
-- 16GB 宿主机：最多同时运行 3 个活跃实例（含 Chromium），或 5 个轻载实例
-- 默认每容器 memory_limit=4GB，防止单实例内存泄漏影响宿主
-- 用户可通过配置调整资源限制
+- 16 GB 宿主机：最多 3 个活跃实例（含 Chromium），或 5 个轻载实例
+- 默认每容器 `memory_limit=4g`，防止单实例影响宿主
+- 可通过 `~/.clawfleet/config.yaml` 调整
 
-## 6. 项目目录结构
+## 7. 项目目录结构
 
 ```
-ClawSandbox/
-├── cmd/
-│   └── clawsandbox/
-│       └── main.go
+ClawFleet/
+├── cmd/clawfleet/              # 二进制入口
+│   └── main.go
 ├── internal/
-│   ├── cli/
-│   │   ├── root.go
-│   │   ├── build.go
-│   │   ├── create.go
-│   │   ├── list.go
-│   │   ├── start.go
-│   │   ├── stop.go
-│   │   ├── destroy.go
-│   │   ├── desktop.go
-│   │   ├── logs.go
-│   │   └── helpers.go
-│   ├── container/
-│   │   ├── client.go
-│   │   ├── manager.go
-│   │   ├── image.go
-│   │   └── network.go
-│   ├── port/
+│   ├── cli/                    # Cobra 命令（24 个文件）
+│   │   ├── root.go             # 根命令，注册子命令
+│   │   ├── create.go           # 实例创建
+│   │   ├── list.go             # 军团列表
+│   │   ├── start/stop/restart/destroy.go
+│   │   ├── desktop.go          # 打开 noVNC 桌面
+│   │   ├── logs.go             # 容器日志
+│   │   ├── configure.go        # 交互式配置向导
+│   │   ├── dashboard*.go       # Dashboard serve/start/stop/restart/status
+│   │   ├── daemon*.go          # 平台特定 daemon 管理
+│   │   ├── snapshot*.go        # 快照 save/list/delete
+│   │   ├── build.go            # 镜像构建命令
+│   │   ├── config_show.go      # 显示配置文件
+│   │   └── version.go          # 版本显示
+│   ├── container/              # Docker 编排（8 个文件）
+│   │   ├── client.go           # Docker 客户端初始化
+│   │   ├── manager.go          # 容器生命周期
+│   │   ├── image.go            # 镜像构建/拉取/检查/标签
+│   │   ├── configure.go        # 多步 OpenClaw 配置
+│   │   ├── network.go          # Docker 网络管理
+│   │   ├── skills.go           # 技能安装/卸载
+│   │   └── stats.go            # 资源统计采集
+│   ├── port/                   # 端口分配器
 │   │   └── allocator.go
-│   ├── state/
-│   │   └── store.go
-│   ├── config/
+│   ├── state/                  # JSON 状态持久化
+│   │   ├── store.go            # 实例元数据
+│   │   ├── assets.go           # 模型/渠道/角色资产
+│   │   └── snapshots.go        # 快照元数据
+│   ├── config/                 # YAML 配置加载
 │   │   └── config.go
-│   └── assets/
-│       ├── embed.go
-│       └── docker/
-│           ├── Dockerfile
-│           ├── supervisord.conf
-│           └── entrypoint.sh
+│   ├── assets/                 # 内嵌 Docker 构建上下文
+│   │   ├── embed.go
+│   │   └── docker/
+│   │       ├── Dockerfile
+│   │       ├── supervisord.conf
+│   │       └── entrypoint.sh
+│   ├── snapshot/               # 灵魂归档逻辑
+│   │   └── snapshot.go
+│   ├── version/                # 构建版本信息
+│   │   └── version.go          # Version + RecommendedOpenClawVersion
+│   └── web/                    # Web Dashboard（15+ 文件）
+│       ├── server.go           # HTTP 服务 + PID 管理
+│       ├── routes.go           # 路由注册
+│       ├── embed.go            # 前端资源内嵌
+│       ├── handlers.go         # 实例生命周期处理器
+│       ├── handlers_assets.go  # 资产 CRUD
+│       ├── handlers_configure.go  # 配置端点
+│       ├── handlers_image.go   # 镜像构建/拉取/版本
+│       ├── handlers_skills.go  # 技能管理
+│       ├── handlers_snapshots.go  # 快照 CRUD
+│       ├── handlers_console.go # 控制台代理（反向代理到 noVNC）
+│       ├── events.go           # 实时更新事件总线
+│       ├── ws_stats.go         # WebSocket：资源统计
+│       ├── ws_logs.go          # WebSocket：容器日志
+│       ├── ws_events.go        # WebSocket：生命周期事件
+│       ├── validate.go         # LLM/渠道凭证验证
+│       └── static/             # 内嵌前端
+│           ├── index.html
+│           ├── css/style.css
+│           └── js/
+│               ├── app.js      # Preact 主应用
+│               ├── api.js      # REST 客户端
+│               ├── ws.js       # WebSocket 管理器
+│               ├── i18n.js     # 国际化
+│               └── components/ # 21 个 Preact 组件
+├── scripts/
+│   ├── install.sh              # 一键安装脚本
+│   └── ensure-go.sh            # Go 版本引导
 ├── docs/
-│   ├── SYSTEM_DESIGN.md        # English (primary)
-│   └── SYSTEM_DESIGN.zh-CN.md  # 中文
-├── go.mod
-├── go.sum
-├── Makefile
-├── README.md
-├── README.zh-CN.md
-└── CLAUDE.md
+│   ├── SYSTEM_DESIGN.md
+│   ├── SYSTEM_DESIGN.zh-CN.md
+│   └── images/                 # 截图
+├── growth/                     # 营销物料
+├── .github/workflows/
+│   └── release.yml             # CI/CD 流水线
+├── .goreleaser.yml             # 多平台发布配置
+├── Makefile                    # 构建目标
+├── CLAUDE.md                   # AI 助手指南
+├── ROADMAP.md                  # 产品路线图
+├── README.md / README.zh-CN.md
+└── LICENSE                     # MIT
 ```
 
-## 7. 技术依赖总览
+## 8. 技术依赖
 
-### 宿主机（ClawSandbox CLI）
+### 宿主机
 | 依赖 | 用途 |
 |------|------|
 | Go 1.25+ | 编译 CLI |
-| Docker Engine | 容器运行时（Docker Desktop for Mac 或 colima） |
+| Docker Engine | 容器运行时（macOS 用 Colima，Linux 用 Docker Engine） |
 
 ### 容器内
 | 依赖 | 版本 | 用途 |
 |------|------|------|
 | Debian Bookworm | 12 | 基础 OS |
 | Node.js | 22 | OpenClaw 运行时 |
-| OpenClaw | latest | AI 助手核心 |
+| OpenClaw | 按 release 锁定 | AI 助手核心 |
 | Chromium (Playwright) | — | 浏览器自动化 |
 | XFCE4 | 4.18 | 轻量桌面环境 |
 | TigerVNC | — | VNC 服务端 |
 | noVNC + websockify | — | Web VNC 客户端 |
 | supervisord | — | 容器内多进程管理 |
 
-### Go 模块依赖
+### Go 模块
 | 模块 | 用途 |
 |------|------|
 | `github.com/spf13/cobra` | CLI 框架 |
 | `github.com/fsouza/go-dockerclient` | Docker Engine API |
+| `github.com/gorilla/websocket` | WebSocket 支持 |
 | `gopkg.in/yaml.v3` | 配置文件解析 |
 
-## 8. 交互界面演进策略
+## 9. CI/CD 流水线
 
-项目采用分阶段交付策略，先跑通核心再打磨体验：
+**触发条件：** 推送匹配 `v*` 的标签（如 `v0.4.0`）
 
-### 阶段一：CLI（开发调试期）
-所有操作通过命令行完成，快速验证核心功能闭环。这一阶段的产出是一个功能完整、可流畅使用的 CLI 工具。
+**任务（并行）：**
 
-### 阶段二：Web 配置页面（开源发布前）
-在 CLI 跑通后，为非技术用户实现 Web UI：
+| 任务 | 工具 | 产出 |
+|------|------|------|
+| `release` | GoReleaser | 4 个平台的 CLI 二进制（darwin/linux × amd64/arm64）→ GitHub Release + checksums |
+| `docker` | docker/build-push-action | 多架构镜像（linux/amd64 + linux/arm64）→ GHCR，版本标签 + `:latest` |
 
-- **军团管理面板**：ClawSandbox 在宿主机启动一个 Web 服务，提供统一的军团总览页面（创建/启停/销毁实例、查看状态）
-- **实例管理后台**：每个龙虾实例有独立的配置页面（LLM Provider、Telegram Bot、模型选择等），用户无需进入桌面终端即可完成 OpenClaw 配置
-- **桌面入口**：页面内嵌或链接到各实例的 noVNC 桌面
+`docker` 任务从 `internal/version/version.go` 中提取 `RecommendedOpenClawVersion`，作为 `OPENCLAW_VERSION` build-arg 传入，确保预构建镜像包含经过测试的 OpenClaw 版本。
 
-CLI 始终保留作为高级用户和自动化场景的入口。
+**发版流程：**
 
-## 9. 实现范围
+```bash
+# 1. 如需更新 OpenClaw 版本，修改 RecommendedOpenClawVersion
+# 2. 打标签并推送
+git tag v0.5.0
+git push origin v0.5.0
+# CI 自动完成：二进制构建、镜像构建推送、GitHub Release 创建
+```
 
-### 阶段一 MVP（CLI）
+## 10. 配置
 
-**包含：**
-- [x] Docker 镜像构建（Dockerfile + supervisord + entrypoint）
-- [x] `build` — 构建 Docker 镜像
-- [x] `create N` — 创建 N 个容器实例
-- [x] `list` — 列出所有实例及状态（实时从 Docker 获取）
-- [x] `start/stop` — 启停实例
-- [x] `destroy [--purge]` — 销毁实例
-- [x] `desktop` — 浏览器打开 noVNC
-- [x] `logs [-f]` — 查看实例日志
-- [x] 端口自动分配和冲突检测
-- [x] 实例数据卷持久化
+**文件：** `~/.clawfleet/config.yaml`
 
-### 阶段二（Web UI）
-- [ ] 军团管理面板（Web 服务）
-- [ ] 实例配置页面（LLM/Telegram 等）
-- [ ] OpenClaw onboard 自动化
+```yaml
+image:
+  name: "ghcr.io/clawfleet/clawfleet"
+  tag: "v0.4.0"             # 由 version.ImageTag() 决定
 
-**不包含（更远期）：**
-- 龙虾间群聊和任务分派
-- 实例模板/预设配置
-- 远程宿主机支持
+ports:
+  novnc_start: 6901         # 顺序分配：6901, 6902, ...
+  gateway_start: 18789      # 顺序分配：18789, 18790, ...
 
-## 10. 验证方案
+resources:
+  memory_limit: "4g"        # 每容器内存上限
+  cpu_limit: 2.0            # 每容器 CPU 上限（核数）
+
+naming:
+  prefix: "claw"            # 实例名：claw-1, claw-2, ...
+```
+
+## 11. 验证方案
+
+### 端到端（一键安装）
+```bash
+# 全新机器
+curl -fsSL https://raw.githubusercontent.com/clawfleet/ClawFleet/main/scripts/install.sh | sh
+# → Docker 已安装、CLI 已下载、镜像已拉取、Dashboard 运行在 :8080
+
+# 验证镜像内 OpenClaw 版本
+docker exec claw-1 npm list -g openclaw
+# → 应显示 RecommendedOpenClawVersion
+```
 
 ### 构建验证
 ```bash
-make build
-clawfleet build
+make build && make test
 ```
 
-### 端到端验证
+### 手动生命周期
 ```bash
-# 1. 创建 2 个实例
 clawfleet create 2
-
-# 2. 确认容器运行中
 clawfleet list
-
-# 3. 访问桌面
-clawfleet desktop claw-1
-# → 浏览器打开 http://localhost:6901，看到 XFCE 桌面
-
-# 4. 在桌面终端中完成 OpenClaw 配置
-openclaw onboard --flow quickstart
-openclaw gateway --port 18789
-# → 在 Chromium 中打开终端输出的地址，确认控制台可用
-
-# 5. 停止/启动
 clawfleet stop claw-1
 clawfleet start claw-1
-# → 确认数据（~/.openclaw）在容器重启后保留
-
-# 6. 销毁
+# → 重启后数据保留
 clawfleet destroy claw-2
-clawfleet list
-# → 确认 claw-2 已移除
 ```
 
 ### 资源验证
 ```bash
 docker stats claw-1 claw-2
-# → 确认内存在 memory_limit 之内
-```
-
-## 11. 版本管理
-
-一次 `git tag` 同时锁定 CLI 和 Docker 镜像的版本，自动发布到 GitHub Release 和 GHCR。
-
-### 架构
-
-```
-git tag v0.1.0 && git push origin v0.1.0
-        │
-        ▼
-   GitHub Actions
-   ┌──────────────────┬──────────────────────┐
-   │  GoReleaser       │  Docker Build+Push    │
-   │  CLI 二进制 x4    │  ghcr.io 镜像         │
-   │  (darwin/linux    │  :0.1.0 + :latest     │
-   │   x amd64/arm64) │                        │
-   └────────┬─────────┴──────────┬─────────────┘
-            ▼                    ▼
-     GitHub Release         ghcr.io/clawfleet/clawfleet
-```
-
-### 共享版本包 (`internal/version/`)
-
-版本元数据（`Version`、`GitCommit`、`BuildDate`）在构建时通过 ldflags 注入到 `internal/version`。`internal/cli/version.go` 和 `internal/config/config.go` 均从此包导入。
-
-`ImageTag()` 函数根据 CLI 版本推导 Docker 镜像标签：
-- release 版本（如 `v0.1.0`）：返回 `0.1.0`
-- dev 版本（无标签）：返回 `latest`
-
-### 镜像命名与标签
-
-- **仓库地址**：`ghcr.io/clawfleet/clawfleet`
-- **默认标签**：运行时通过 `version.ImageTag()` 动态确定
-- `clawfleet build` 同时打 `:<version>` 和 `:latest` 两个标签
-- `clawfleet create` 使用 `:<version>` 确保 CLI 与镜像版本一致
-
-### 自动拉取镜像
-
-当 `clawfleet create`（或仪表盘的创建接口）发现本地没有镜像时，自动尝试从 GHCR 拉取。联网用户无需执行 `clawfleet build`。
-
-```
-本地未找到镜像
-  → docker pull ghcr.io/clawfleet/clawfleet:0.1.0
-  → 成功？继续创建
-  → 失败？提示用户执行 clawfleet build
-```
-
-### CI 流水线 (`.github/workflows/release.yml`)
-
-触发条件：`v*` 标签推送。两个并行任务：
-
-| 任务 | 工具 | 产出 |
-|------|------|------|
-| `release` | GoReleaser | 4 个平台的 CLI 二进制 → GitHub Release |
-| `docker` | docker/build-push-action | 镜像 → `ghcr.io/clawfleet/clawfleet:<version>` + `:latest` |
-
-### 发版流程（维护者操作）
-
-```bash
-git checkout main
-git pull origin main
-git tag v0.1.0
-git push origin v0.1.0
-# CI 自动完成剩余工作
+# → 内存在 memory_limit 限制之内
 ```


### PR DESCRIPTION
## Summary
- CI Docker build was using `openclaw@latest` instead of the tested `RecommendedOpenClawVersion`, causing users to receive untested OpenClaw versions
- Extract `RecommendedOpenClawVersion` from `version.go` and pass as `OPENCLAW_VERSION` build-arg in `release.yml`
- Add "Version Pinning & Stability Buffer" engineering principle to `CLAUDE.md`
- Rewrite `SYSTEM_DESIGN.md` (EN + ZH) from v0.1 → v0.4 reflecting current architecture

## Verified
- Smoke-tested install.sh on fresh Ubuntu (43.128.112.94): full flow works
- Confirmed current v0.4.0 image has `openclaw@2026.3.28` (npm latest at CI time) instead of recommended `2026.3.23-2` — proves the bug
- Verified sed extraction: `grep 'RecommendedOpenClawVersion =' version.go` correctly outputs `2026.3.23-2`

## Test plan
- [ ] Merge and tag `v0.4.1`
- [ ] Verify new GHCR image layer shows `OPENCLAW_VERSION=2026.3.23-2` (not `latest`)
- [ ] Run `install.sh` on clean machine, check `docker exec claw-1 npm list -g openclaw` shows `2026.3.23-2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)