### PR TITLE
fix: Docker install fallback + destroy -f flag

### DIFF
--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -14,18 +14,22 @@ import (
 	"github.com/clawfleet/clawfleet/internal/state"
 )
 
-var destroyPurge bool
+var (
+	destroyPurge bool
+	destroyForce bool
+)
 
 var destroyCmd = &cobra.Command{
 	Use:     "destroy <name|all>",
 	Short:   "Destroy a claw instance (data is kept by default)",
 	Args:    cobra.ExactArgs(1),
-	Example: "  clawfleet destroy claw-1\n  clawfleet destroy all --purge",
+	Example: "  clawfleet destroy claw-1\n  clawfleet destroy all --purge\n  clawfleet destroy claw-1 -f --purge",
 	RunE:    runDestroy,
 }
 
 func init() {
 	destroyCmd.Flags().BoolVar(&destroyPurge, "purge", false, "Also delete instance data from disk")
+	destroyCmd.Flags().BoolVarP(&destroyForce, "force", "f", false, "Skip confirmation prompt")
 }
 
 func runDestroy(cmd *cobra.Command, args []string) error {
@@ -39,7 +43,7 @@ func runDestroy(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no instance found: %s", args[0])
 	}
 
-	if len(targets) > 1 || destroyPurge {
+	if !destroyForce && (len(targets) > 1 || destroyPurge) {
 		purgeNote := ""
 		if destroyPurge {
 			purgeNote = " (and their data)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -188,6 +188,19 @@ install_docker_linux() {
     sudo service docker start 2>/dev/null || true
   fi
 
+  # If official Docker install failed, fallback to distro package
+  sleep 3
+  if ! docker info >/dev/null 2>&1 && ! sudo docker info >/dev/null 2>&1; then
+    warn "Official Docker install incomplete, trying distro package..."
+    sudo apt-get update -qq 2>/dev/null
+    sudo apt-get install -y docker.io 2>&1 | tail -3
+    if command -v systemctl >/dev/null 2>&1; then
+      sudo systemctl enable --now docker 2>/dev/null || true
+    else
+      sudo service docker start 2>/dev/null || true
+    fi
+  fi
+
   # Add user to docker group
   if ! groups | grep -q docker; then
     sudo usermod -aG docker "$USER" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- **install.sh**: if `get.docker.com` fails to produce a running Docker daemon (common on Chinese cloud servers with broken apt mirrors), automatically fallback to distro package (`docker.io`) before giving up
- **destroy**: add `-f`/`--force` flag to skip confirmation prompt, enabling scripted cleanup (`clawfleet destroy all -f --purge`)

## Context
Both issues discovered during v0.4.1 smoke testing on Tencent Cloud Ubuntu (43.128.112.94):
1. `get.docker.com` partially failed due to `mirrors.tencentyun.com` fetch errors, Docker daemon didn't start → script failed. Manual `apt-get install docker.io` fixed it.
2. `clawfleet destroy claw-1 -f` reported `unknown shorthand flag` — no force flag existed.

## Test plan
- [ ] On a fresh Linux server without Docker: verify install.sh completes even if `get.docker.com` fails
- [ ] `clawfleet destroy claw-1 -f --purge` skips confirmation
- [ ] `clawfleet destroy all --purge` still prompts without `-f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)