### PR TITLE
docs: SSH tunnel port 8081 + PR workflow rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ Then create a feature branch from the up-to-date main. Never work directly on a 
 
 **Never push directly to main.** All changes must go through a pull request, even for docs or config-only changes.
 
+**One PR = one branch, all commits before merge.** Never push additional commits to a branch after its PR has been merged — those commits will not be on main. If you have more changes to make, create a new branch from the latest main and open a new PR. Always check `gh pr view <number> --json state` before pushing to a PR branch.
+
 ## Build/Test/Lint Commands
 
 ```bash
@@ -151,7 +153,7 @@ The output of any tech research should be a clear recommendation: compete / inte
 
 ## Growth Strategy Sync
 
-<!-- strategy-bulletin-version: 1 -->
+<!-- strategy-bulletin-version: 2 -->
 
 All Marketer-Sessions (growth, content, distribution) MUST re-read `growth/STRATEGY_BULLETIN.md` before every action cycle (writing content, publishing, making distribution decisions). This file contains the live strategy, target user definition, active decisions, and constraints. It is updated by the lead Marketer-Session; the version comment above is bumped on each update to trigger CLAUDE.md change notifications to all running sessions.
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,16 @@ clawfleet dashboard stop
 clawfleet dashboard start --host 127.0.0.1
 ```
 
-The **Control Panel** (OpenClaw's built-in web UI) requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) for WebSocket device identity. On a remote server accessed via plain HTTP, use an SSH tunnel:
+To access the Dashboard from your local machine via SSH tunnel:
 
 ```bash
-ssh -L 8080:127.0.0.1:8080 user@your-server
-# Then open http://localhost:8080 in your browser
+ssh -L 8081:127.0.0.1:8080 user@your-server
+# Then open http://localhost:8081 in your browser
 ```
 
-All other Dashboard features (fleet management, configuration, Restart Bot, etc.) work without a tunnel.
+Port 8081 is used here because 8080 is often occupied by a local ClawFleet instance. You can use any free local port.
+
+The **Control Panel** (OpenClaw's built-in web UI) requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) for WebSocket device identity — the SSH tunnel provides this. All other Dashboard features (fleet management, configuration, Restart Bot, etc.) work without a tunnel via direct HTTP.
 </details>
 
 > **Manual install?** See the [Getting Started](https://github.com/clawfleet/ClawFleet/wiki/Getting-Started) wiki page.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -74,14 +74,16 @@ clawfleet dashboard stop
 clawfleet dashboard start --host 127.0.0.1
 ```
 
-**控制面板**（OpenClaw 内置 Web UI）的 WebSocket 连接需要浏览器[安全上下文](https://developer.mozilla.org/zh-CN/docs/Web/Security/Secure_Contexts)。远程服务器通过 HTTP 访问时，请使用 SSH 隧道：
+通过 SSH 隧道从本地访问远程服务器上的 Dashboard：
 
 ```bash
-ssh -L 8080:127.0.0.1:8080 user@your-server
-# 然后浏览器访问 http://localhost:8080
+ssh -L 8081:127.0.0.1:8080 user@your-server
+# 然后浏览器访问 http://localhost:8081
 ```
 
-其他 Dashboard 功能（实例管理、配置、重启龙虾等）无需隧道即可正常使用。
+这里使用 8081 端口是因为本地 8080 通常已被本地 ClawFleet 占用。你可以使用任意空闲的本地端口。
+
+**控制面板**（OpenClaw 内置 Web UI）的 WebSocket 连接需要浏览器[安全上下文](https://developer.mozilla.org/zh-CN/docs/Web/Security/Secure_Contexts)——SSH 隧道可满足此要求。其他 Dashboard 功能（实例管理、配置、重启龙虾等）无需隧道，可通过 HTTP 直接访问。
 </details>
 
 > **手动安装？** 参阅[快速入门](https://github.com/clawfleet/ClawFleet/wiki/Getting-Started)。


### PR DESCRIPTION
## Summary
- **README (EN + ZH)**: SSH tunnel example changed from `8081` to avoid conflict with local ClawFleet on port 8080
- **CLAUDE.md**: Added branch discipline rule — never push to a branch after its PR is merged; always create a new branch from latest main

## Context
Twice pushed commits to branches whose PRs were already merged, resulting in changes silently missing from main. The CLAUDE.md rule prevents all PSE-Sessions from repeating this mistake.

## Test plan
- [x] Verify README SSH tunnel instructions are clear
- [x] Verify CLAUDE.md rule is in the Workflow section

🤖 Generated with [Claude Code](https://claude.com/claude-code)