### PR TITLE
docs: SSH tunnel runs in background with -fN

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,12 @@ clawfleet dashboard start --host 127.0.0.1
 To access the Dashboard from your local machine via SSH tunnel:
 
 ```bash
-ssh -L 8081:127.0.0.1:8080 user@your-server
+ssh -fNL 8081:127.0.0.1:8080 user@your-server
 # Then open http://localhost:8081 in your browser
+# To stop the tunnel later: kill $(lsof -ti:8081)
 ```
 
-Port 8081 is used here because 8080 is often occupied by a local ClawFleet instance. You can use any free local port.
+The `-fN` flags run the tunnel in the background so you can close your terminal without breaking the connection. Port 8081 is used here because 8080 is often occupied by a local ClawFleet instance.
 
 The **Control Panel** (OpenClaw's built-in web UI) requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) for WebSocket device identity — the SSH tunnel provides this. All other Dashboard features (fleet management, configuration, Restart Bot, etc.) work without a tunnel via direct HTTP.
 </details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -77,11 +77,12 @@ clawfleet dashboard start --host 127.0.0.1
 通过 SSH 隧道从本地访问远程服务器上的 Dashboard：
 
 ```bash
-ssh -L 8081:127.0.0.1:8080 user@your-server
+ssh -fNL 8081:127.0.0.1:8080 user@your-server
 # 然后浏览器访问 http://localhost:8081
+# 关闭隧道: kill $(lsof -ti:8081)
 ```
 
-这里使用 8081 端口是因为本地 8080 通常已被本地 ClawFleet 占用。你可以使用任意空闲的本地端口。
+`-fN` 参数使隧道在后台运行，关闭终端不会中断连接。这里使用 8081 端口是因为本地 8080 通常已被本地 ClawFleet 占用。
 
 **控制面板**（OpenClaw 内置 Web UI）的 WebSocket 连接需要浏览器[安全上下文](https://developer.mozilla.org/zh-CN/docs/Web/Security/Secure_Contexts)——SSH 隧道可满足此要求。其他 Dashboard 功能（实例管理、配置、重启龙虾等）无需隧道，可通过 HTTP 直接访问。
 </details>


### PR DESCRIPTION
## Summary
- SSH tunnel command changed from `ssh -L` to `ssh -fNL` so the tunnel runs in the background
- Added `kill $(lsof -ti:8081)` command to stop the tunnel
- Updated both EN and ZH READMEs

## Context
Without `-fN`, closing the terminal kills the tunnel and breaks Dashboard access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)