### PR TITLE
feat: display version in Dashboard toolbar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MODULE     = github.com/clawfleet/clawfleet
 IMAGE      = ghcr.io/clawfleet/clawfleet:latest
 GO_BOOTSTRAP = ./scripts/ensure-go.sh --print-path
 
-VERSION    ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+VERSION    ?= $(shell git describe --tags --always --dirty="-pre" 2>/dev/null || echo dev)
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 BUILD_DATE ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/clawfleet/clawfleet/internal/config"
+	versionpkg "github.com/clawfleet/clawfleet/internal/version"
 	"github.com/clawfleet/clawfleet/internal/container"
 	"github.com/clawfleet/clawfleet/internal/port"
 	"github.com/clawfleet/clawfleet/internal/snapshot"
@@ -560,4 +561,13 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 	}); err != nil {
 		log.Printf("writeError: %v", err)
 	}
+}
+
+// handleVersion returns the ClawFleet version.
+func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": map[string]string{
+			"version": versionpkg.Version,
+		},
+	})
 }

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -51,6 +51,9 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/snapshots", s.handleCreateSnapshot)
 	mux.HandleFunc("DELETE /api/v1/snapshots/{id}", s.handleDeleteSnapshot)
 
+	// Version
+	mux.HandleFunc("GET /api/v1/version", s.handleVersion)
+
 	// OAuth
 	mux.HandleFunc("POST /api/v1/oauth/codex/start", s.handleCodexOAuthStart)
 	mux.HandleFunc("POST /api/v1/oauth/codex/callback", s.handleCodexOAuthCallback)

--- a/internal/web/static/css/style.css
+++ b/internal/web/static/css/style.css
@@ -60,6 +60,13 @@ body {
   letter-spacing: -0.02em;
 }
 
+.toolbar-version {
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  opacity: 0.7;
+  font-weight: 400;
+}
+
 .toolbar-count {
   font-size: 0.8rem;
   color: var(--text-dim);

--- a/internal/web/static/js/api.js
+++ b/internal/web/static/js/api.js
@@ -30,6 +30,9 @@ export const api = {
   configureInstance: (name, config) => request('POST', `/instances/${encodeURIComponent(name)}/configure`, config),
   getConfigStatus:   (name)        => request('GET',  `/instances/${encodeURIComponent(name)}/configure/status`),
 
+  // Version
+  version:          () => request('GET', '/version'),
+
   // Image
   imageStatus:      () => request('GET', '/image/status'),
   openclawVersions: () => request('GET', '/image/openclaw-versions'),

--- a/internal/web/static/js/components/toolbar.js
+++ b/internal/web/static/js/components/toolbar.js
@@ -1,5 +1,6 @@
 import { html, useState, useRef, useEffect } from '../lib.js';
 import { useLang } from '../i18n.js';
+import { api } from '../api.js';
 
 const LANGUAGES = [
   { code: 'en', label: 'English' },
@@ -9,7 +10,12 @@ const LANGUAGES = [
 export function Toolbar() {
   const { lang, setLang } = useLang();
   const [open, setOpen] = useState(false);
+  const [version, setVersion] = useState('');
   const ref = useRef(null);
+
+  useEffect(() => {
+    api.version().then(d => setVersion(d.version || '')).catch(() => {});
+  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -27,6 +33,7 @@ export function Toolbar() {
       <div class="toolbar-brand">
         <span class="toolbar-logo">🦞</span>
         <h1 class="toolbar-title">ClawFleet</h1>
+        ${version && html`<span class="toolbar-version">${version}</span>`}
       </div>
       <div class="toolbar-right">
         <div class="lang-dropdown" ref=${ref}>


### PR DESCRIPTION
## Summary
- New `GET /api/v1/version` endpoint returns ClawFleet binary version
- Toolbar displays version next to logo (e.g. "v1.0.0")
- Makefile: dev builds show "-pre" suffix instead of "-dirty"

## Test plan
- [x] Build passes
- [x] Version API returns correct version
- [x] Toolbar shows version in Dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)