### PR TITLE
docs: add dashboard screenshot and install video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 [中文文档](./README.zh-CN.md)
 
+![Dashboard](docs/images/fleet.png)
+
 ## Get Started
 
 ```bash
@@ -21,11 +23,13 @@ curl -fsSL https://clawfleet.io/install.sh | sh
 
 10 minutes: Docker installed, image pulled, dashboard running at `http://localhost:8080`. Log in with your ChatGPT account — your existing Plus subscription covers inference, no API keys needed.
 
+[![Install Demo](https://img.shields.io/badge/▶_Install_Demo-30s-red?style=for-the-badge&logo=youtube)](https://youtu.be/FSxC2vUQ-6k)
+
 ---
 
 **Imagine buying N dedicated Mac Minis**, each running its own OpenClaw instance, fully isolated, collaborating in Discord. Your own AI company — data stays on your hardware, no SaaS subscription.
 
-**ClawFleet makes that free.** Each instance runs in its own Docker container with isolated filesystem and networking. On your existing Mac or Linux box. ~1.5 GB RAM per instance.
+**ClawFleet makes that free.** Each instance runs in its own Docker container with isolated filesystem and networking. On your existing Mac or Linux box. ~500 MB RAM per instance.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ curl -fsSL https://clawfleet.io/install.sh | sh
 
 10 minutes: Docker installed, image pulled, dashboard running at `http://localhost:8080`. Log in with your ChatGPT account — your existing Plus subscription covers inference, no API keys needed.
 
-[![Install Demo](https://img.shields.io/badge/▶_Install_Demo-30s-red?style=for-the-badge&logo=youtube)](https://youtu.be/FSxC2vUQ-6k)
+[![Install Demo](https://img.youtube.com/vi/FSxC2vUQ-6k/maxresdefault.jpg)](https://youtu.be/FSxC2vUQ-6k)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 
 [中文文档](./README.zh-CN.md)
 
+**Imagine buying N dedicated Mac Minis**, each running its own OpenClaw instance, fully isolated, collaborating in Discord. Your own AI company — data stays on your hardware, no SaaS subscription.
+
+**ClawFleet makes that free.** Each instance runs in its own Docker container with isolated filesystem and networking. On your existing Mac or Linux box. ~500 MB RAM per instance.
+
 ![Dashboard](docs/images/fleet.png)
 
 ## Get Started
@@ -21,15 +25,10 @@
 curl -fsSL https://clawfleet.io/install.sh | sh
 ```
 
-10 minutes: Docker installed, image pulled, dashboard running at `http://localhost:8080`. Log in with your ChatGPT account — your existing Plus subscription covers inference, no API keys needed.
+5 minutes: Docker installed, image pulled, dashboard running at `http://localhost:8080`. Log in with your ChatGPT account — your existing Plus subscription covers inference, no API keys needed.
 
 [![Install Demo](https://img.youtube.com/vi/FSxC2vUQ-6k/maxresdefault.jpg)](https://youtu.be/FSxC2vUQ-6k)
-
----
-
-**Imagine buying N dedicated Mac Minis**, each running its own OpenClaw instance, fully isolated, collaborating in Discord. Your own AI company — data stays on your hardware, no SaaS subscription.
-
-**ClawFleet makes that free.** Each instance runs in its own Docker container with isolated filesystem and networking. On your existing Mac or Linux box. ~500 MB RAM per instance.
+[![▶ Watch Install Demo (30s)](https://img.shields.io/badge/▶_Watch_Install_Demo-30s-red?style=for-the-badge&logo=youtube)](https://youtu.be/FSxC2vUQ-6k)
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,8 @@
 
 [English](./README.md)
 
+![Dashboard](docs/images/fleet.png)
+
 ## 开始使用
 
 ```bash
@@ -21,11 +23,13 @@ curl -fsSL https://clawfleet.io/install.sh | sh
 
 10 分钟：Docker 自动安装、镜像拉取完毕、Dashboard 在 `http://localhost:8080` 运行。用 ChatGPT 账号登录——已有的 Plus 订阅即可驱动推理，无需 API Key。
 
+[![安装演示](https://img.shields.io/badge/▶_安装演示-30秒-red?style=for-the-badge&logo=youtube)](https://youtu.be/FSxC2vUQ-6k)
+
 ---
 
 **想象你买了 N 台专用 Mac Mini**，每台跑一个 OpenClaw 实例，互相隔离，在 Discord 群里自动协作。一家属于你的 AI 公司——数据在你手里，不付订阅费。
 
-**ClawFleet 让这件事免费。** 每个实例跑在独立的 Docker 容器中，隔离的文件系统和网络。在你现有的 Mac 或 Linux 上运行。每个实例约 1.5 GB 内存。
+**ClawFleet 让这件事免费。** 每个实例跑在独立的 Docker 容器中，隔离的文件系统和网络。在你现有的 Mac 或 Linux 上运行。每个实例约 500 MB 内存。
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,10 @@
 
 [English](./README.md)
 
+**想象你买了 N 台专用 Mac Mini**，每台跑一个 OpenClaw 实例，互相隔离，在 Discord 群里自动协作。一家属于你的 AI 公司——数据在你手里，不付订阅费。
+
+**ClawFleet 让这件事免费。** 每个实例跑在独立的 Docker 容器中，隔离的文件系统和网络。在你现有的 Mac 或 Linux 上运行。每个实例约 500 MB 内存。
+
 ![Dashboard](docs/images/fleet.png)
 
 ## 开始使用
@@ -21,15 +25,10 @@
 curl -fsSL https://clawfleet.io/install.sh | sh
 ```
 
-10 分钟：Docker 自动安装、镜像拉取完毕、Dashboard 在 `http://localhost:8080` 运行。用 ChatGPT 账号登录——已有的 Plus 订阅即可驱动推理，无需 API Key。
+5 分钟：Docker 自动安装、镜像拉取完毕、Dashboard 在 `http://localhost:8080` 运行。用 ChatGPT 账号登录——已有的 Plus 订阅即可驱动推理，无需 API Key。
 
 [![安装演示](https://img.youtube.com/vi/FSxC2vUQ-6k/maxresdefault.jpg)](https://youtu.be/FSxC2vUQ-6k)
-
----
-
-**想象你买了 N 台专用 Mac Mini**，每台跑一个 OpenClaw 实例，互相隔离，在 Discord 群里自动协作。一家属于你的 AI 公司——数据在你手里，不付订阅费。
-
-**ClawFleet 让这件事免费。** 每个实例跑在独立的 Docker 容器中，隔离的文件系统和网络。在你现有的 Mac 或 Linux 上运行。每个实例约 500 MB 内存。
+[![▶ 观看安装演示 (30秒)](https://img.shields.io/badge/▶_观看安装演示-30秒-red?style=for-the-badge&logo=youtube)](https://youtu.be/FSxC2vUQ-6k)
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@ curl -fsSL https://clawfleet.io/install.sh | sh
 
 10 分钟：Docker 自动安装、镜像拉取完毕、Dashboard 在 `http://localhost:8080` 运行。用 ChatGPT 账号登录——已有的 Plus 订阅即可驱动推理，无需 API Key。
 
-[![安装演示](https://img.shields.io/badge/▶_安装演示-30秒-red?style=for-the-badge&logo=youtube)](https://youtu.be/FSxC2vUQ-6k)
+[![安装演示](https://img.youtube.com/vi/FSxC2vUQ-6k/maxresdefault.jpg)](https://youtu.be/FSxC2vUQ-6k)
 
 ---
 


### PR DESCRIPTION
## Summary
- Move fleet.png dashboard screenshot to first screen (both EN and CN READMEs)
- Add YouTube install demo badge (30s video, unlisted)
- Fix RAM data: ~1.5GB → ~500MB per instance (verified from real dashboard)

Pre-launch README polish for T-1.

## Test plan
- [x] fleet.png renders correctly on GitHub
- [x] YouTube badge links to correct video
- [x] Chinese README matches English changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)