### PR TITLE
docs: recommend Docker Desktop for Mac users

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ curl -fsSL https://clawfleet.io/install.sh | sh
 ## Requirements
 
 - macOS or Linux
+- **Mac users:** strongly recommended to install [Docker Desktop](https://www.docker.com/products/docker-desktop/) first for the best experience
+  <br><sub>Otherwise ClawFleet will automatically install Colima as an alternative Docker runtime.</sub>
 
 ## Install Details
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -48,6 +48,8 @@ curl -fsSL https://clawfleet.io/install.sh | sh
 ## 前置要求
 
 - macOS 或 Linux
+- **Mac 用户：** 强烈建议预先安装 [Docker Desktop](https://www.docker.com/products/docker-desktop/) 以获得最佳体验
+  <br><sub>否则 ClawFleet 会自动安装 Colima 作为替代容器运行时。</sub>
 
 ## 安装详情
 


### PR DESCRIPTION
## Summary
Add Docker Desktop recommendation to Requirements section in both READMEs.
Main text: strongly recommended. Small text: Colima as automatic fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)