### PR TITLE
chore: bump OpenClaw to 2026.4.11

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13,7 +13,7 @@ var releaseTagPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
 
 // RecommendedOpenClawVersion is the OpenClaw version that has been tested
 // with this release of ClawFleet. Updated with each ClawFleet release.
-const RecommendedOpenClawVersion = "2026.4.9"
+const RecommendedOpenClawVersion = "2026.4.11"
 
 // ImageTag returns the Docker image tag corresponding to this CLI version.
 // Only exact release tags (e.g. "v0.1.0") map to release images. Local git


### PR DESCRIPTION
## Summary
- Update RecommendedOpenClawVersion from 2026.4.9 to 2026.4.11

## Test plan
- [x] Image build with 2026.4.11
- [x] Instance create + configure (gpt-5-mini)
- [x] Gateway health check pass
- [x] Chat compatibility — 0 OpenAI errors in session logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)