### PR TITLE
release: v1.0.2 — OpenClaw 4.14 + Claude policy notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ curl -fsSL https://clawfleet.io/install.sh | sh
 
 5 minutes: Docker installed, image pulled, dashboard running at `http://localhost:8080`. Log in with your ChatGPT account — your existing Plus subscription covers inference, no API keys needed.
 
+> **Not affected by the 2026-04-04 Claude subscription policy change.** ClawFleet's recommended path uses ChatGPT (Codex OAuth) — your existing ChatGPT Plus/Pro subscription works as-is. No migration needed.
+
 [![Install Demo](https://img.youtube.com/vi/jE5ZR8g477s/maxresdefault.jpg)](https://youtu.be/jE5ZR8g477s)
 [![▶ Watch Install Demo (30s)](https://img.shields.io/badge/▶_Watch_Install_Demo-30s-red?style=for-the-badge&logo=youtube)](https://youtu.be/jE5ZR8g477s)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,6 +27,8 @@ curl -fsSL https://clawfleet.io/install.sh | sh
 
 5 分钟：Docker 自动安装、镜像拉取完毕、Dashboard 在 `http://localhost:8080` 运行。用 ChatGPT 账号登录——已有的 Plus 订阅即可驱动推理，无需 API Key。
 
+> **不受 2026-04-04 Claude 订阅策略变更影响。** ClawFleet 推荐使用 ChatGPT (Codex OAuth) —— 你现有的 ChatGPT Plus/Pro 订阅直接可用，无需迁移。
+
 [![安装演示](https://img.youtube.com/vi/jE5ZR8g477s/maxresdefault.jpg)](https://youtu.be/jE5ZR8g477s)
 [![▶ 观看安装演示 (30秒)](https://img.shields.io/badge/▶_观看安装演示-30秒-red?style=for-the-badge&logo=youtube)](https://youtu.be/jE5ZR8g477s)
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13,7 +13,7 @@ var releaseTagPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
 
 // RecommendedOpenClawVersion is the OpenClaw version that has been tested
 // with this release of ClawFleet. Updated with each ClawFleet release.
-const RecommendedOpenClawVersion = "2026.4.11"
+const RecommendedOpenClawVersion = "2026.4.14"
 
 // ImageTag returns the Docker image tag corresponding to this CLI version.
 // Only exact release tags (e.g. "v0.1.0") map to release images. Local git


### PR DESCRIPTION
## Summary
Responding to the 2026-04-04 Claude subscription policy change within the 48h community discussion window.

- Bump OpenClaw from 4.11 to 4.14 (tested yesterday: all pass)
- Add README notice: ClawFleet's Codex OAuth path is unaffected by the Claude policy change

## Context
Anthropic cut Claude Pro/Max subscription support for OpenClaw on 4/4. Transition credits expire 4/17. Our Codex OAuth path (ChatGPT subscription) is the natural migration target. This release signals "product is alive" during the critical discussion window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)