### PR TITLE
feat: Hermes integration + clawfleet shell + OpenClaw 4.15

### DIFF
--- a/docs/superpowers/plans/2026-04-21-hermes-integration.md
+++ b/docs/superpowers/plans/2026-04-21-hermes-integration.md
@@ -1,0 +1,670 @@
+# Hermes Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable ClawFleet to create and manage Hermes containers alongside OpenClaw in a unified Fleet.
+
+**Architecture:** Hermes is lifecycle-only — ClawFleet manages container create/start/stop/destroy and exposes Hermes native ports. OpenClaw code paths are untouched. RuntimeType field on Instance drives branching at create time and UI rendering.
+
+**Tech Stack:** Go, Preact (htm), Docker API (go-dockerclient)
+
+---
+
+### Task 1: Data Model — Instance.RuntimeType
+
+**Files:**
+- Modify: `internal/state/store.go:19-28`
+
+- [ ] **Step 1: Add RuntimeType to Instance struct**
+
+```go
+type Instance struct {
+	Name             string    `json:"name"`
+	ContainerID      string    `json:"container_id"`
+	Status           string    `json:"status"`
+	Ports            Ports     `json:"ports"`
+	CreatedAt        time.Time `json:"created_at"`
+	ModelAssetID     string    `json:"model_asset_id,omitempty"`
+	ChannelAssetID   string    `json:"channel_asset_id,omitempty"`
+	CharacterAssetID string    `json:"character_asset_id,omitempty"`
+	RuntimeType      string    `json:"runtime_type,omitempty"`
+}
+```
+
+- [ ] **Step 2: Add IsHermes helper**
+
+```go
+func (inst *Instance) IsHermes() bool {
+	return inst.RuntimeType == "hermes"
+}
+```
+
+- [ ] **Step 3: Build and run existing tests**
+
+Run: `make build && make test`
+Expected: All pass — field is omitempty, backward compatible with existing state.json.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/state/store.go
+git commit -m "feat: add RuntimeType field to Instance for multi-runtime support"
+```
+
+---
+
+### Task 2: Config — Hermes Image Defaults
+
+**Files:**
+- Modify: `internal/config/config.go`
+
+- [ ] **Step 1: Add HermesConfig and constants**
+
+Add after existing constants:
+```go
+const (
+	DefaultHermesImageName = "nousresearch/hermes-agent"
+	DefaultHermesImageTag  = "latest"
+)
+```
+
+Add HermesConfig struct after NamingConfig:
+```go
+type HermesConfig struct {
+	ImageName string `yaml:"image_name"`
+	ImageTag  string `yaml:"image_tag"`
+}
+```
+
+Add Hermes field to Config struct:
+```go
+type Config struct {
+	Image     ImageConfig    `yaml:"image"`
+	Hermes    HermesConfig   `yaml:"hermes"`
+	Ports     PortsConfig    `yaml:"ports"`
+	Resources ResourceConfig `yaml:"resources"`
+	Naming    NamingConfig   `yaml:"naming"`
+}
+```
+
+Add HermesImageRef method:
+```go
+func (c *Config) HermesImageRef() string {
+	return fmt.Sprintf("%s:%s", c.Hermes.ImageName, c.Hermes.ImageTag)
+}
+```
+
+Update DefaultConfig:
+```go
+func DefaultConfig() *Config {
+	return &Config{
+		Image:  ImageConfig{Name: DefaultImageName, Tag: version.ImageTag()},
+		Hermes: HermesConfig{ImageName: DefaultHermesImageName, ImageTag: DefaultHermesImageTag},
+		Ports:  PortsConfig{NoVNCBase: DefaultNoVNCBase, GatewayBase: DefaultGatewayBase},
+		Resources: ResourceConfig{
+			MemoryLimit: DefaultMemoryLimit,
+			CPULimit:    DefaultCPULimit,
+		},
+		Naming: NamingConfig{Prefix: DefaultNamingPrefix},
+	}
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `make build`
+Expected: Compiles clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/config/config.go
+git commit -m "feat: add Hermes image config with defaults"
+```
+
+---
+
+### Task 3: Container Manager — Runtime-Aware Creation
+
+**Files:**
+- Modify: `internal/container/manager.go`
+
+- [ ] **Step 1: Add RuntimeType to CreateParams**
+
+```go
+type CreateParams struct {
+	Name        string
+	ImageRef    string
+	NoVNCPort   int
+	GatewayPort int
+	DataDir     string
+	MemoryBytes int64
+	NanoCPUs    int64
+	RuntimeType string // "openclaw" or "hermes"
+}
+```
+
+- [ ] **Step 2: Make Create() runtime-aware**
+
+Replace the hardcoded port bindings and volume binds in `Create()`:
+
+```go
+func Create(cli *docker.Client, p CreateParams) (string, error) {
+	var portBindings map[docker.Port][]docker.PortBinding
+	var exposedPorts map[docker.Port]struct{}
+	var binds []string
+	var env []string
+
+	if p.RuntimeType == "hermes" {
+		// Hermes: Dashboard (9119) + Gateway (3000)
+		portBindings = map[docker.Port][]docker.PortBinding{
+			"9119/tcp": {{HostIP: "127.0.0.1", HostPort: strconv.Itoa(p.NoVNCPort)}},
+			"3000/tcp": {{HostIP: "127.0.0.1", HostPort: strconv.Itoa(p.GatewayPort)}},
+		}
+		exposedPorts = map[docker.Port]struct{}{
+			"9119/tcp": {},
+			"3000/tcp": {},
+		}
+		binds = []string{fmt.Sprintf("%s:/opt/data", p.DataDir)}
+		env = []string{
+			fmt.Sprintf("HERMES_UID=%d", os.Getuid()),
+			fmt.Sprintf("HERMES_GID=%d", os.Getgid()),
+		}
+	} else {
+		// OpenClaw: noVNC (6901) + Gateway bridge (18790)
+		portBindings = map[docker.Port][]docker.PortBinding{
+			"6901/tcp":  {{HostIP: "127.0.0.1", HostPort: strconv.Itoa(p.NoVNCPort)}},
+			"18790/tcp": {{HostIP: "127.0.0.1", HostPort: strconv.Itoa(p.GatewayPort)}},
+		}
+		exposedPorts = map[docker.Port]struct{}{
+			"6901/tcp":  {},
+			"18790/tcp": {},
+		}
+		binds = []string{fmt.Sprintf("%s:/home/node/.openclaw", p.DataDir)}
+		env = []string{
+			"PLAYWRIGHT_BROWSERS_PATH=/ms-playwright",
+		}
+	}
+
+	container, err := cli.CreateContainer(docker.CreateContainerOptions{
+		Name: p.Name,
+		Config: &docker.Config{
+			Image:        p.ImageRef,
+			ExposedPorts: exposedPorts,
+			Labels:       map[string]string{cfg.LabelManaged: "true"},
+			Env:          env,
+		},
+		HostConfig: &docker.HostConfig{
+			Binds:        binds,
+			PortBindings: portBindings,
+			NetworkMode:  cfg.NetworkName,
+			Memory:       p.MemoryBytes,
+			NanoCPUs:     p.NanoCPUs,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("creating container %s: %w", p.Name, err)
+	}
+	return container.ID, nil
+}
+```
+
+- [ ] **Step 3: Add `os` import**
+
+Add `"os"` to imports.
+
+- [ ] **Step 4: Build**
+
+Run: `make build`
+Expected: Compiles clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/container/manager.go
+git commit -m "feat: runtime-aware container creation (OpenClaw + Hermes ports/volumes)"
+```
+
+---
+
+### Task 4: Create Handler — Runtime Type Passthrough
+
+**Files:**
+- Modify: `internal/web/handlers.go`
+
+- [ ] **Step 1: Add RuntimeType to createRequest**
+
+```go
+type createRequest struct {
+	Count        int    `json:"count"`
+	SnapshotName string `json:"snapshot_name,omitempty"`
+	RuntimeType  string `json:"runtime_type,omitempty"`
+}
+```
+
+- [ ] **Step 2: Update handleCreateInstances — image selection and data dir**
+
+In `handleCreateInstances`, after parsing the request, add image selection logic. Replace the current image check block and instance creation loop with runtime-aware logic:
+
+After `cfg := s.config`, add:
+```go
+	runtimeType := req.RuntimeType
+	if runtimeType == "" {
+		runtimeType = "openclaw"
+	}
+
+	// Select image based on runtime
+	var imageRef, imageName, imageTag string
+	if runtimeType == "hermes" {
+		imageRef = cfg.HermesImageRef()
+		imageName = cfg.Hermes.ImageName
+		imageTag = cfg.Hermes.ImageTag
+	} else {
+		imageRef = cfg.ImageRef()
+		imageName = cfg.Image.Name
+		imageTag = cfg.Image.Tag
+	}
+```
+
+Replace `container.ImageExists(s.docker, cfg.ImageRef())` with `container.ImageExists(s.docker, imageRef)` and update the pull call to use `imageName, imageTag`.
+
+In the instance creation loop, update the data directory:
+```go
+	dataSuffix := "openclaw"
+	if runtimeType == "hermes" {
+		dataSuffix = "hermes"
+	}
+	instanceDataDir := filepath.Join(dataDir, "data", name, dataSuffix)
+```
+
+Disable snapshots for Hermes:
+```go
+	if req.SnapshotName != "" && runtimeType == "hermes" {
+		writeError(w, http.StatusBadRequest, "Soul Archive is not supported for Hermes instances")
+		return
+	}
+```
+
+Pass RuntimeType to CreateParams and to Instance:
+```go
+	containerID, err := container.Create(s.docker, container.CreateParams{
+		// ... existing fields
+		RuntimeType: runtimeType,
+	})
+```
+
+```go
+	inst := &state.Instance{
+		// ... existing fields
+		RuntimeType: runtimeType,
+	}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `make build`
+Expected: Compiles clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/web/handlers.go
+git commit -m "feat: create handler supports runtime_type parameter"
+```
+
+---
+
+### Task 5: Handler Guards — Reject OpenClaw-Only Ops for Hermes
+
+**Files:**
+- Modify: `internal/web/handlers_configure.go`
+- Modify: `internal/web/handlers_skills.go`
+- Modify: `internal/web/handlers.go` (restart-bot, reset)
+
+- [ ] **Step 1: Add guard to handleConfigureInstance**
+
+At the top of `handleConfigureInstance`, after loading the instance:
+```go
+	if inst.IsHermes() {
+		writeError(w, http.StatusBadRequest,
+			"Not available for Hermes instances. Use the Hermes Dashboard to configure.")
+		return
+	}
+```
+
+- [ ] **Step 2: Add guard to handleRestartBot**
+
+Same pattern at the top of `handleRestartBot`.
+
+- [ ] **Step 3: Add guard to all skills handlers**
+
+Add the same guard to `handleListInstanceSkills`, `handleInstallSkill`, `handleUninstallSkill`.
+
+- [ ] **Step 4: Add guard to handleResetInstance**
+
+Same pattern.
+
+- [ ] **Step 5: Build and test**
+
+Run: `make build && make test`
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/web/handlers_configure.go internal/web/handlers_skills.go internal/web/handlers.go
+git commit -m "feat: reject OpenClaw-only operations for Hermes instances"
+```
+
+---
+
+### Task 6: Instance List Response — Runtime-Specific Ports
+
+**Files:**
+- Modify: `internal/web/handlers.go` (instanceResponse and handleListInstances)
+
+- [ ] **Step 1: Add runtime fields to instanceResponse**
+
+```go
+type instanceResponse struct {
+	// ... existing fields
+	RuntimeType        string `json:"runtime_type,omitempty"`
+	HermesDashboardPort int   `json:"hermes_dashboard_port,omitempty"`
+	HermesGatewayPort   int   `json:"hermes_gateway_port,omitempty"`
+}
+```
+
+- [ ] **Step 2: Populate runtime fields in handleListInstances**
+
+When building instanceResponse, add:
+```go
+	resp.RuntimeType = inst.RuntimeType
+	if inst.IsHermes() {
+		resp.HermesDashboardPort = inst.Ports.NoVNC   // reuse NoVNC slot for Hermes Dashboard
+		resp.HermesGatewayPort = inst.Ports.Gateway     // reuse Gateway slot for Hermes Gateway
+	}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `make build`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/web/handlers.go
+git commit -m "feat: instance list includes runtime type and Hermes port info"
+```
+
+---
+
+### Task 7: Frontend — Create Dialog Runtime Dropdown
+
+**Files:**
+- Modify: `internal/web/static/js/components/create-dialog.js`
+- Modify: `internal/web/static/js/api.js`
+- Modify: `internal/web/static/js/i18n.js`
+
+- [ ] **Step 1: Add i18n strings**
+
+English:
+```js
+'create.runtime': 'Runtime',
+'create.runtimeOpenClaw': 'OpenClaw',
+'create.runtimeHermes': 'Hermes',
+```
+
+Chinese:
+```js
+'create.runtime': '运行时',
+'create.runtimeOpenClaw': 'OpenClaw',
+'create.runtimeHermes': 'Hermes',
+```
+
+- [ ] **Step 2: Add runtime state and dropdown to create-dialog.js**
+
+Add state: `const [runtime, setRuntime] = useState('openclaw');`
+
+Add dropdown before instance count:
+```js
+<label class="form-label">
+  ${t('create.runtime')}
+  <select class="form-input" value=${runtime} onChange=${(e) => setRuntime(e.target.value)}>
+    <option value="openclaw">${t('create.runtimeOpenClaw')}</option>
+    <option value="hermes">${t('create.runtimeHermes')}</option>
+  </select>
+</label>
+```
+
+Disable snapshot dropdown when runtime is hermes.
+
+- [ ] **Step 3: Pass runtime_type in API call**
+
+In api.js, update `createInstances`:
+```js
+createInstances: (count, snapshotName, runtimeType) =>
+  request('POST', '/instances', {
+    count,
+    ...(snapshotName && { snapshot_name: snapshotName }),
+    ...(runtimeType && runtimeType !== 'openclaw' && { runtime_type: runtimeType }),
+  }),
+```
+
+Update the call site in create-dialog.js to pass `runtime`.
+
+- [ ] **Step 4: Build**
+
+Run: `make build`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/web/static/js/components/create-dialog.js internal/web/static/js/api.js internal/web/static/js/i18n.js
+git commit -m "feat: create dialog with runtime selector (OpenClaw / Hermes)"
+```
+
+---
+
+### Task 8: Frontend — Instance Card Runtime Badge + Conditional Buttons
+
+**Files:**
+- Modify: `internal/web/static/js/components/instance-card.js`
+- Modify: `internal/web/static/js/app.js`
+- Modify: `internal/web/static/js/i18n.js`
+
+- [ ] **Step 1: Add i18n strings**
+
+English:
+```js
+'card.hermesDashboard': '⚕ Dashboard',
+'runtime.openclaw': 'OpenClaw',
+'runtime.hermes': 'Hermes',
+```
+
+Chinese:
+```js
+'card.hermesDashboard': '⚕ 控制台',
+'runtime.openclaw': 'OpenClaw',
+'runtime.hermes': 'Hermes',
+```
+
+- [ ] **Step 2: Update instance-card.js**
+
+Add runtime badge next to instance name:
+```js
+${instance.runtime_type === 'hermes'
+  ? html`<span class="runtime-badge runtime-hermes">☤ Hermes</span>`
+  : html`<span class="runtime-badge runtime-openclaw">🦞</span>`
+}
+```
+
+Conditionally show buttons:
+```js
+${!isHermes && html`
+  <button class="btn btn-sm btn-desktop" onClick=${onDesktop}>Desktop</button>
+  <button class="btn btn-sm btn-desktop" onClick=${onConsole}>Control Panel</button>
+  <button class="btn btn-sm" onClick=${onConfigure}>Configure</button>
+`}
+${isHermes && html`
+  <button class="btn btn-sm btn-desktop" onClick=${onHermesDashboard}>⚕ Dashboard</button>
+`}
+```
+
+Where `isHermes = instance.runtime_type === 'hermes'`.
+
+Show Skills, Save Soul, Restart Bot only for OpenClaw:
+```js
+${!isHermes && html`
+  <button ...>Skills</button>
+  <button ...>Save Soul</button>
+  <button ...>Restart Bot</button>
+`}
+```
+
+- [ ] **Step 3: Add onHermesDashboard handler in app.js**
+
+```js
+const onHermesDashboard = (name) => {
+  const inst = instances.find(i => i.name === name);
+  if (inst && inst.hermes_dashboard_port) {
+    window.open(`http://localhost:${inst.hermes_dashboard_port}/`, '_blank');
+  }
+};
+```
+
+Pass it to Dashboard and InstanceCard components.
+
+- [ ] **Step 4: Add CSS for runtime badge**
+
+In `style.css`:
+```css
+.runtime-badge {
+  font-size: 0.65rem;
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin-left: 8px;
+  font-weight: 500;
+}
+.runtime-hermes {
+  background: rgba(76, 175, 80, 0.2);
+  color: #4caf50;
+}
+.runtime-openclaw {
+  opacity: 0.5;
+}
+```
+
+- [ ] **Step 5: Build**
+
+Run: `make build`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/web/static/js/components/instance-card.js internal/web/static/js/app.js internal/web/static/js/i18n.js internal/web/static/css/style.css
+git commit -m "feat: instance card with runtime badge and conditional buttons"
+```
+
+---
+
+### Task 9: Hermes Auto-Pull + Image Status
+
+**Files:**
+- Modify: `internal/web/handlers.go` (create handler — already done in Task 4)
+- Modify: `internal/web/handlers_image.go`
+
+- [ ] **Step 1: Update handleImageStatus to include Hermes**
+
+Return both OpenClaw and Hermes image status:
+```go
+func (s *Server) handleImageStatus(w http.ResponseWriter, r *http.Request) {
+	openclawExists, _ := container.ImageExists(s.docker, s.config.ImageRef())
+	hermesExists, _ := container.ImageExists(s.docker, s.config.HermesImageRef())
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": map[string]any{
+			"image":        s.config.ImageRef(),
+			"built":        openclawExists,
+			"hermes_image": s.config.HermesImageRef(),
+			"hermes_built": hermesExists,
+		},
+	})
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `make build`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/web/handlers_image.go
+git commit -m "feat: image status includes Hermes image availability"
+```
+
+---
+
+### Task 10: Smoke Test
+
+- [ ] **Step 1: Build and start Dashboard**
+
+```bash
+make build
+./bin/clawfleet dashboard serve &
+```
+
+- [ ] **Step 2: Create OpenClaw instance — verify zero regression**
+
+```bash
+curl -sf -X POST http://localhost:8080/api/v1/instances \
+  -H 'Content-Type: application/json' -d '{"count":1}'
+```
+
+Verify: status=running, has novnc_port and gateway_port, runtime_type empty or "openclaw".
+
+- [ ] **Step 3: Create Hermes instance**
+
+```bash
+curl -sf -X POST http://localhost:8080/api/v1/instances \
+  -H 'Content-Type: application/json' -d '{"count":1,"runtime_type":"hermes"}'
+```
+
+Verify: status=running, has hermes_dashboard_port and hermes_gateway_port.
+
+- [ ] **Step 4: Verify Hermes Dashboard accessible**
+
+```bash
+curl -sf -o /dev/null -w "%{http_code}" http://localhost:{hermes_dashboard_port}/
+```
+
+Expected: 200
+
+- [ ] **Step 5: Verify OpenClaw-only ops rejected for Hermes**
+
+```bash
+curl -sf -X POST http://localhost:8080/api/v1/instances/{hermes-name}/configure \
+  -H 'Content-Type: application/json' -d '{"model_asset_id":"any"}'
+```
+
+Expected: 400 with "Not available for Hermes instances"
+
+- [ ] **Step 6: Verify mixed Fleet list**
+
+```bash
+curl -sf http://localhost:8080/api/v1/instances
+```
+
+Expected: Both instances in list, different runtime_type values.
+
+- [ ] **Step 7: Clean up**
+
+```bash
+curl -sf -X POST http://localhost:8080/api/v1/instances/batch-destroy \
+  -H 'Content-Type: application/json' -d '{"names":["claw-1","claw-2"]}'
+```
+
+- [ ] **Step 8: Commit test results**
+
+```bash
+git commit --allow-empty -m "test: Hermes integration smoke test passed"
+```

--- a/docs/superpowers/specs/2026-04-21-hermes-integration-and-upgrade-design.md
+++ b/docs/superpowers/specs/2026-04-21-hermes-integration-and-upgrade-design.md
@@ -1,0 +1,245 @@
+# Hermes Integration + Upgrade Flow — Design Spec
+
+> Date: 2026-04-21 | Status: Draft
+
+## Goal
+
+1. ClawFleet manages Hermes containers alongside OpenClaw — unified Fleet, separate runtimes
+2. `clawfleet upgrade` CLI command + Dashboard upgrade trigger with observable progress
+
+## Scope
+
+**In scope:**
+- Create Hermes instances from Dashboard/CLI (container lifecycle only)
+- Expose Hermes native ports (Dashboard 9119, Gateway 3000) for full native experience
+- Unified instance list with runtime type badge
+- `clawfleet upgrade` command (download binary + pull image + restart daemon)
+- Dashboard upgrade banner + trigger + progress log
+
+**Out of scope:**
+- ClawFleet-managed Configure for Hermes (user configures via Hermes native Dashboard)
+- Skills management for Hermes
+- Roster/SOUL.md injection for Hermes
+- Cross-runtime collaboration (OpenClaw ↔ Hermes)
+
+---
+
+## Part 1: Hermes Integration
+
+### 1.1 Data Model
+
+**Instance** — add `RuntimeType` field:
+```go
+type Instance struct {
+    // ... existing fields
+    RuntimeType string `json:"runtime_type,omitempty"` // "" or "openclaw" = OpenClaw, "hermes" = Hermes
+}
+```
+
+Empty string = OpenClaw (backward compatible with all existing instances).
+
+**Config** — add Hermes image config:
+```go
+type HermesConfig struct {
+    ImageName string `yaml:"image_name"`
+    ImageTag  string `yaml:"image_tag"`
+}
+```
+
+Default: `nousresearch/hermes-agent:latest`
+
+### 1.2 Container Creation
+
+**Port allocation:** Unified pool (scheme C). Each instance gets ports from the same sequential allocator regardless of runtime.
+
+OpenClaw instance ports:
+- noVNC: 6901+N → container 6901
+- Gateway LAN bridge: 18789+N → container 18790
+
+Hermes instance ports:
+- Dashboard: 9119+N → container 9119
+- Gateway: 3000+N → container 3000
+
+The allocator already uses `port.FindAvailable()` which probes availability. The per-runtime port mapping is determined at create time based on `RuntimeType`.
+
+**Volume mapping:**
+- OpenClaw: `~/.clawfleet/data/<name>/openclaw` → `/home/node/.openclaw`
+- Hermes: `~/.clawfleet/data/<name>/hermes` → `/opt/data`
+
+**Image selection:**
+- `RuntimeType == "hermes"` → use `HermesConfig.ImageName:ImageTag`
+- Otherwise → use existing `ImageConfig.Name:Tag`
+
+### 1.3 Instance Card (Frontend)
+
+- Badge: 🦞 for OpenClaw, ☤ for Hermes (or text label)
+- OpenClaw cards: show Desktop, Control Panel, Configure, Skills, Save Soul, Restart Bot (existing)
+- Hermes cards: show **Dashboard** (opens `localhost:{hermes_dashboard_port}`), **Suspend/Resume/Destroy** (lifecycle only)
+- Hermes cards do NOT show: Configure, Skills, Save Soul, Restart Bot (these are OpenClaw-specific)
+
+### 1.4 Create Dialog (Frontend)
+
+Add "Runtime" dropdown above instance count:
+- OpenClaw (default)
+- Hermes
+
+Selection determines which image is used. Soul Archive only available for OpenClaw (Hermes snapshots not supported in v1).
+
+### 1.5 API Changes
+
+**POST /api/v1/instances** — add optional `runtime_type` field:
+```json
+{"count": 1, "runtime_type": "hermes"}
+```
+
+Default: `"openclaw"` (backward compatible).
+
+**GET /api/v1/instances** — response includes `runtime_type` and runtime-specific port names:
+```json
+{
+  "name": "claw-4",
+  "runtime_type": "hermes",
+  "hermes_dashboard_port": 9119,
+  "hermes_gateway_port": 3000
+}
+```
+
+**OpenClaw-specific endpoints** — return 400 for Hermes instances:
+- `POST /instances/{name}/configure`
+- `POST /instances/{name}/restart-bot`
+- `GET /instances/{name}/skills`
+- `POST /instances/{name}/skills/install`
+- `DELETE /instances/{name}/skills/{slug}`
+
+Error: `{"error": {"message": "Not available for Hermes instances. Use the Hermes Dashboard to configure."}}`
+
+### 1.6 Hermes Image Management
+
+**No build support for Hermes.** Hermes uses the official `nousresearch/hermes-agent` image from Docker Hub. ClawFleet pulls it, doesn't build it.
+
+**Auto-pull:** Same as OpenClaw — if image is missing at create time, auto-pull from registry.
+
+**Image page:** Show Hermes image status alongside OpenClaw. Read-only (pull only, no build/version selector).
+
+### 1.7 Files Changed
+
+| File | Change |
+|------|--------|
+| `internal/state/store.go` | `Instance.RuntimeType` field |
+| `internal/config/config.go` | `HermesConfig` struct + defaults |
+| `internal/container/manager.go` | Runtime-aware port mapping + volume binding |
+| `internal/web/handlers.go` | Create handler reads `runtime_type`, rejects OpenClaw-only ops for Hermes |
+| `internal/web/handlers_configure.go` | Reject configure for Hermes instances |
+| `internal/web/handlers_skills.go` | Reject skills ops for Hermes instances |
+| `internal/web/static/js/components/create-dialog.js` | Runtime dropdown |
+| `internal/web/static/js/components/instance-card.js` | Runtime badge + conditional buttons |
+| `internal/web/static/js/api.js` | Pass `runtime_type` in create |
+| `internal/web/static/js/i18n.js` | Runtime labels + Hermes strings |
+
+---
+
+## Part 2: Upgrade Flow
+
+### 2.1 CLI: `clawfleet upgrade`
+
+**Steps:**
+1. Check current version (`version.Version`)
+2. Fetch latest release from GitHub API (`/repos/clawfleet/ClawFleet/releases/latest`)
+3. If already latest → print "Already up to date" and exit
+4. Download new binary (same platform/arch detection as install.sh)
+5. Verify checksum
+6. Replace current binary (atomic: write temp file → rename)
+7. Pull new Docker image(s) (OpenClaw + Hermes if configured)
+8. Restart Dashboard daemon
+9. Print summary: `v1.1.0 → v1.2.0`
+
+**Flags:**
+- `clawfleet upgrade` — upgrade to latest
+- `clawfleet upgrade --version v1.2.0` — upgrade to specific version
+- `clawfleet upgrade --check` — check if upgrade available, don't apply
+
+**Error handling:**
+- If binary replacement fails (permissions) → suggest `sudo clawfleet upgrade`
+- If image pull fails → warn but continue (image will auto-pull on next create)
+- If daemon restart fails → print manual restart command
+
+### 2.2 Dashboard: Upgrade Banner + Trigger
+
+**Version check:** Dashboard periodically checks GitHub API for latest release (on startup + every 6 hours). If newer version exists, show banner at top of page:
+
+```
+ClawFleet v1.2.0 available (current: v1.1.0) — [Upgrade Now]
+```
+
+**Upgrade trigger:** Click "Upgrade Now" → SSE stream endpoint (same pattern as image build/pull):
+- `POST /api/v1/upgrade` — starts upgrade process, streams progress logs
+- Progress: "Downloading binary..." → "Verifying checksum..." → "Replacing binary..." → "Pulling images..." → "Restarting daemon..."
+- On success: banner changes to "Upgrade complete. Refresh to load new version."
+- On failure: show error, suggest CLI fallback
+
+### 2.3 API
+
+**GET /api/v1/upgrade/check** — returns:
+```json
+{
+  "data": {
+    "current": "v1.1.0",
+    "latest": "v1.2.0",
+    "update_available": true,
+    "release_url": "https://github.com/clawfleet/ClawFleet/releases/tag/v1.2.0"
+  }
+}
+```
+
+**POST /api/v1/upgrade** — SSE stream, same pattern as `/api/v1/image/build`:
+```
+data: Downloading clawfleet_1.2.0_darwin_arm64.tar.gz...
+data: Verifying checksum...
+data: Replacing binary...
+data: Pulling OpenClaw image ghcr.io/clawfleet/clawfleet:v1.2.0...
+data: Pulling Hermes image nousresearch/hermes-agent:latest...
+data: Restarting Dashboard...
+event: done
+data: Upgraded from v1.1.0 to v1.2.0
+```
+
+### 2.4 Self-Upgrade Safety
+
+The binary is replacing itself while potentially running. Safety measures:
+
+1. Write new binary to temp file in same directory (ensures same filesystem)
+2. `os.Rename()` for atomic replacement (POSIX guarantees atomicity on same fs)
+3. Dashboard daemon restart uses `exec` syscall (new process from new binary)
+4. If anything fails before rename → old binary untouched, no corruption
+
+### 2.5 Files Changed
+
+| File | Change |
+|------|--------|
+| `internal/cli/upgrade.go` | New CLI command |
+| `internal/web/handlers_upgrade.go` | New: check + upgrade SSE endpoints |
+| `internal/web/routes.go` | Register upgrade routes |
+| `internal/web/static/js/components/toolbar.js` | Upgrade banner + button |
+| `internal/web/static/js/api.js` | Upgrade API calls |
+| `internal/web/static/js/i18n.js` | Upgrade strings |
+
+---
+
+## Implementation Order
+
+1. **Instance RuntimeType** — data model + config (foundation for everything)
+2. **Hermes container creation** — manager.go port/volume mapping
+3. **API + handler guards** — reject OpenClaw-only ops for Hermes
+4. **Frontend** — create dialog runtime dropdown + instance card badge/buttons
+5. **Upgrade CLI** — `clawfleet upgrade` command
+6. **Upgrade Dashboard** — banner + trigger + SSE progress
+7. **Testing** — smoke test both runtimes + upgrade flow
+
+## Verification
+
+- Create OpenClaw instance → all existing features work (zero regression)
+- Create Hermes instance → container running, Dashboard port accessible, user can configure via native Hermes Dashboard
+- Mixed Fleet → both types in same list, badges correct, buttons appropriate per type
+- `clawfleet upgrade --check` → shows available version
+- `clawfleet upgrade` → binary replaced, images pulled, daemon restarted
+- Dashboard upgrade banner → visible when update available, SSE progress works

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,6 +29,7 @@ func Execute() {
 		dashboardCmd,
 		configCmd,
 		configureCmd,
+		shellCmd,
 		snapshotCmd,
 		versionCmd,
 	)

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/state"
+)
+
+var shellCmd = &cobra.Command{
+	Use:   "shell <name>",
+	Short: "Open an interactive shell inside an instance",
+	Long: `Opens an interactive terminal session inside a running instance.
+
+For Hermes instances, this launches the Hermes interactive CLI (TUI).
+For OpenClaw instances, this opens a bash shell.`,
+	Args:    cobra.ExactArgs(1),
+	Example: "  clawfleet shell claw-1",
+	RunE:    runShell,
+}
+
+func runShell(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	cli, err := container.NewClient()
+	if err != nil {
+		return err
+	}
+
+	store, err := state.Load()
+	if err != nil {
+		return err
+	}
+
+	inst := store.Get(name)
+	if inst == nil {
+		return fmt.Errorf("instance %s not found", name)
+	}
+
+	status, _, _ := container.Status(cli, inst.ContainerID)
+	if status != "running" {
+		return fmt.Errorf("instance %s is not running", name)
+	}
+
+	// Build the docker exec command
+	var shellArgs []string
+	if inst.IsHermes() {
+		// Hermes: activate venv and launch interactive TUI
+		shellArgs = []string{
+			"docker", "exec", "-it", inst.ContainerID,
+			"bash", "-c",
+			"source /opt/hermes/.venv/bin/activate && exec hermes",
+		}
+	} else {
+		// OpenClaw: open a bash shell as the node user
+		shellArgs = []string{
+			"docker", "exec", "-it", "-u", "node", inst.ContainerID,
+			"bash",
+		}
+	}
+
+	// Use syscall.Exec to replace the current process so the terminal
+	// is fully interactive (stdin/stdout/stderr pass through directly).
+	dockerPath, err := exec.LookPath("docker")
+	if err != nil {
+		return fmt.Errorf("docker not found in PATH: %w", err)
+	}
+
+	fmt.Printf("Connecting to %s...\n", name)
+	return syscall.Exec(dockerPath, shellArgs, os.Environ())
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,12 +18,16 @@ const (
 	DefaultCPULimit     = 2.0
 	DefaultNamingPrefix = "claw"
 
+	DefaultHermesImageName = "nousresearch/hermes-agent"
+	DefaultHermesImageTag  = "latest"
+
 	NetworkName  = "clawfleet-net"
 	LabelManaged = "clawfleet.managed"
 )
 
 type Config struct {
 	Image     ImageConfig    `yaml:"image"`
+	Hermes    HermesConfig   `yaml:"hermes"`
 	Ports     PortsConfig    `yaml:"ports"`
 	Resources ResourceConfig `yaml:"resources"`
 	Naming    NamingConfig   `yaml:"naming"`
@@ -48,14 +52,24 @@ type NamingConfig struct {
 	Prefix string `yaml:"prefix"`
 }
 
+type HermesConfig struct {
+	ImageName string `yaml:"image_name"`
+	ImageTag  string `yaml:"image_tag"`
+}
+
 func (c *Config) ImageRef() string {
 	return fmt.Sprintf("%s:%s", c.Image.Name, c.Image.Tag)
 }
 
+func (c *Config) HermesImageRef() string {
+	return fmt.Sprintf("%s:%s", c.Hermes.ImageName, c.Hermes.ImageTag)
+}
+
 func DefaultConfig() *Config {
 	return &Config{
-		Image: ImageConfig{Name: DefaultImageName, Tag: version.ImageTag()},
-		Ports: PortsConfig{NoVNCBase: DefaultNoVNCBase, GatewayBase: DefaultGatewayBase},
+		Image:  ImageConfig{Name: DefaultImageName, Tag: version.ImageTag()},
+		Hermes: HermesConfig{ImageName: DefaultHermesImageName, ImageTag: DefaultHermesImageTag},
+		Ports:  PortsConfig{NoVNCBase: DefaultNoVNCBase, GatewayBase: DefaultGatewayBase},
 		Resources: ResourceConfig{
 			MemoryLimit: DefaultMemoryLimit,
 			CPULimit:    DefaultCPULimit,

--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -21,19 +22,45 @@ type CreateParams struct {
 	DataDir     string
 	MemoryBytes int64
 	NanoCPUs    int64
+	RuntimeType string
 }
 
 func Create(cli *docker.Client, p CreateParams) (string, error) {
-	portBindings := map[docker.Port][]docker.PortBinding{
-		"6901/tcp":  {{HostIP: "127.0.0.1", HostPort: strconv.Itoa(p.NoVNCPort)}},
-		"18790/tcp": {{HostIP: "127.0.0.1", HostPort: strconv.Itoa(p.GatewayPort)}},
-	}
-	exposedPorts := map[docker.Port]struct{}{
-		"6901/tcp":  {},
-		"18790/tcp": {},
-	}
+	var (
+		portBindings map[docker.Port][]docker.PortBinding
+		exposedPorts map[docker.Port]struct{}
+		binds        []string
+		env          []string
+	)
 
-	binds := []string{fmt.Sprintf("%s:/home/node/.openclaw", p.DataDir)}
+	if p.RuntimeType == "hermes" {
+		portBindings = map[docker.Port][]docker.PortBinding{
+			"9119/tcp": {{HostIP: "127.0.0.1", HostPort: strconv.Itoa(p.NoVNCPort)}},
+			"3000/tcp": {{HostIP: "127.0.0.1", HostPort: strconv.Itoa(p.GatewayPort)}},
+		}
+		exposedPorts = map[docker.Port]struct{}{
+			"9119/tcp": {},
+			"3000/tcp": {},
+		}
+		binds = []string{fmt.Sprintf("%s:/opt/data", p.DataDir)}
+		env = []string{
+			fmt.Sprintf("HERMES_UID=%d", os.Getuid()),
+			fmt.Sprintf("HERMES_GID=%d", os.Getgid()),
+		}
+	} else {
+		portBindings = map[docker.Port][]docker.PortBinding{
+			"6901/tcp":  {{HostIP: "127.0.0.1", HostPort: strconv.Itoa(p.NoVNCPort)}},
+			"18790/tcp": {{HostIP: "127.0.0.1", HostPort: strconv.Itoa(p.GatewayPort)}},
+		}
+		exposedPorts = map[docker.Port]struct{}{
+			"6901/tcp":  {},
+			"18790/tcp": {},
+		}
+		binds = []string{fmt.Sprintf("%s:/home/node/.openclaw", p.DataDir)}
+		env = []string{
+			"PLAYWRIGHT_BROWSERS_PATH=/ms-playwright",
+		}
+	}
 
 	container, err := cli.CreateContainer(docker.CreateContainerOptions{
 		Name: p.Name,
@@ -41,9 +68,7 @@ func Create(cli *docker.Client, p CreateParams) (string, error) {
 			Image:        p.ImageRef,
 			ExposedPorts: exposedPorts,
 			Labels:       map[string]string{cfg.LabelManaged: "true"},
-			Env: []string{
-				"PLAYWRIGHT_BROWSERS_PATH=/ms-playwright",
-			},
+			Env:          env,
 		},
 		HostConfig: &docker.HostConfig{
 			Binds:        binds,

--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -62,17 +62,36 @@ func Create(cli *docker.Client, p CreateParams) (string, error) {
 		}
 	}
 
-	// Hermes needs an explicit startup command (dashboard server).
-	// Without it, the entrypoint defaults to interactive chat and exits immediately.
+	// Hermes: run both dashboard (config UI on :9119) and gateway (messaging on :3000).
+	// We override the entrypoint to run setup + multi-process launch in one script.
+	// The official entrypoint does: UID/GID remap → gosu drop → dir/config bootstrap
+	// → skill sync → exec hermes. We replicate the essential setup steps here.
 	var cmd []string
+	var entrypoint []string
 	if p.RuntimeType == "hermes" {
-		cmd = []string{"dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open", "--insecure"}
+		entrypoint = []string{"/bin/bash", "-c"}
+		cmd = []string{
+			`set -e; export HERMES_HOME="${HERMES_HOME:-/opt/data}"; ` +
+				// Activate Python venv
+				`source /opt/hermes/.venv/bin/activate; ` +
+				// Bootstrap dirs and config (same as official entrypoint.sh)
+				`mkdir -p "$HERMES_HOME"/{cron,sessions,logs,hooks,memories,skills,skins,plans,workspace,home}; ` +
+				`[ -f "$HERMES_HOME/.env" ] || cp /opt/hermes/.env.example "$HERMES_HOME/.env"; ` +
+				`[ -f "$HERMES_HOME/config.yaml" ] || cp /opt/hermes/cli-config.yaml.example "$HERMES_HOME/config.yaml"; ` +
+				`[ -f "$HERMES_HOME/SOUL.md" ] || cp /opt/hermes/docker/SOUL.md "$HERMES_HOME/SOUL.md"; ` +
+				// Sync bundled skills
+				`python3 /opt/hermes/tools/skills_sync.py 2>/dev/null || true; ` +
+				// Launch dashboard in background, gateway as foreground process
+				`hermes dashboard --host 0.0.0.0 --port 9119 --no-open --insecure & ` +
+				`exec hermes gateway run`,
+		}
 	}
 
 	container, err := cli.CreateContainer(docker.CreateContainerOptions{
 		Name: p.Name,
 		Config: &docker.Config{
 			Image:        p.ImageRef,
+			Entrypoint:   entrypoint,
 			Cmd:          cmd,
 			ExposedPorts: exposedPorts,
 			Labels:       map[string]string{cfg.LabelManaged: "true"},

--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -62,10 +62,18 @@ func Create(cli *docker.Client, p CreateParams) (string, error) {
 		}
 	}
 
+	// Hermes needs an explicit startup command (dashboard server).
+	// Without it, the entrypoint defaults to interactive chat and exits immediately.
+	var cmd []string
+	if p.RuntimeType == "hermes" {
+		cmd = []string{"dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open", "--insecure"}
+	}
+
 	container, err := cli.CreateContainer(docker.CreateContainerOptions{
 		Name: p.Name,
 		Config: &docker.Config{
 			Image:        p.ImageRef,
+			Cmd:          cmd,
 			ExposedPorts: exposedPorts,
 			Labels:       map[string]string{cfg.LabelManaged: "true"},
 			Env:          env,

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -25,6 +25,12 @@ type Instance struct {
 	ModelAssetID     string    `json:"model_asset_id,omitempty"`
 	ChannelAssetID   string    `json:"channel_asset_id,omitempty"`
 	CharacterAssetID string    `json:"character_asset_id,omitempty"`
+	RuntimeType      string    `json:"runtime_type,omitempty"`
+}
+
+// IsHermes reports whether this instance uses the Hermes runtime.
+func (inst *Instance) IsHermes() bool {
+	return inst.RuntimeType == "hermes"
 }
 
 type Store struct {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -13,7 +13,7 @@ var releaseTagPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
 
 // RecommendedOpenClawVersion is the OpenClaw version that has been tested
 // with this release of ClawFleet. Updated with each ClawFleet release.
-const RecommendedOpenClawVersion = "2026.4.14"
+const RecommendedOpenClawVersion = "2026.4.15"
 
 // ImageTag returns the Docker image tag corresponding to this CLI version.
 // Only exact release tags (e.g. "v0.1.0") map to release images. Local git

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -458,6 +458,11 @@ func (s *Server) handleResetInstance(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("instance %s not found", name))
 		return
 	}
+	if inst.IsHermes() {
+		writeError(w, http.StatusBadRequest,
+			"Not available for Hermes instances. Use the Hermes Dashboard.")
+		return
+	}
 
 	// Stop openclaw gateway if running.
 	status, _, _ := container.Status(s.docker, inst.ContainerID)
@@ -562,6 +567,11 @@ func (s *Server) handleRestartBot(w http.ResponseWriter, r *http.Request) {
 	inst := store.Get(name)
 	if inst == nil {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("instance %s not found", name))
+		return
+	}
+	if inst.IsHermes() {
+		writeError(w, http.StatusBadRequest,
+			"Not available for Hermes instances. Use the Hermes Dashboard.")
 		return
 	}
 	if inst.Status != "running" {

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -85,6 +85,7 @@ func (s *Server) handleListInstances(w http.ResponseWriter, r *http.Request) {
 type createRequest struct {
 	Count        int    `json:"count"`
 	SnapshotName string `json:"snapshot_name,omitempty"`
+	RuntimeType  string `json:"runtime_type,omitempty"`
 }
 
 // handleCreateInstances creates N new instances.
@@ -101,19 +102,35 @@ func (s *Server) handleCreateInstances(w http.ResponseWriter, r *http.Request) {
 
 	cfg := s.config
 
-	exists, err := container.ImageExists(s.docker, cfg.ImageRef())
+	runtimeType := req.RuntimeType
+	if runtimeType == "" {
+		runtimeType = "openclaw"
+	}
+
+	var imageRef, imageName, imageTag string
+	if runtimeType == "hermes" {
+		imageRef = cfg.HermesImageRef()
+		imageName = cfg.Hermes.ImageName
+		imageTag = cfg.Hermes.ImageTag
+	} else {
+		imageRef = cfg.ImageRef()
+		imageName = cfg.Image.Name
+		imageTag = cfg.Image.Tag
+	}
+
+	exists, err := container.ImageExists(s.docker, imageRef)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	if !exists {
-		log.Printf("Image %s not found locally, pulling from registry...", cfg.ImageRef())
-		if err := container.PullImage(s.docker, cfg.Image.Name, cfg.Image.Tag, io.Discard); err != nil {
+		log.Printf("Image %s not found locally, pulling from registry...", imageRef)
+		if err := container.PullImage(s.docker, imageName, imageTag, io.Discard); err != nil {
 			writeError(w, http.StatusPreconditionFailed, fmt.Sprintf(
-				"Image %s not found locally and pull failed: %v", cfg.ImageRef(), err))
+				"Image %s not found locally and pull failed: %v", imageRef, err))
 			return
 		}
-		log.Printf("Image %s pulled successfully", cfg.ImageRef())
+		log.Printf("Image %s pulled successfully", imageRef)
 	}
 
 	if err := container.EnsureNetwork(s.docker); err != nil {
@@ -158,9 +175,18 @@ func (s *Server) handleCreateInstances(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		instanceDataDir := filepath.Join(dataDir, "data", name, "openclaw")
+		dataSuffix := "openclaw"
+		if runtimeType == "hermes" {
+			dataSuffix = "hermes"
+		}
+		instanceDataDir := filepath.Join(dataDir, "data", name, dataSuffix)
 		if err := os.MkdirAll(instanceDataDir, 0755); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		if req.SnapshotName != "" && runtimeType == "hermes" {
+			writeError(w, http.StatusBadRequest, "Soul Archive is not supported for Hermes instances")
 			return
 		}
 
@@ -174,12 +200,13 @@ func (s *Server) handleCreateInstances(w http.ResponseWriter, r *http.Request) {
 
 		containerID, err := container.Create(s.docker, container.CreateParams{
 			Name:        name,
-			ImageRef:    cfg.ImageRef(),
+			ImageRef:    imageRef,
 			NoVNCPort:   novncPort,
 			GatewayPort: gatewayPort,
 			DataDir:     instanceDataDir,
 			MemoryBytes: memBytes,
 			NanoCPUs:    nanoCPUs,
+			RuntimeType: runtimeType,
 		})
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
@@ -197,6 +224,7 @@ func (s *Server) handleCreateInstances(w http.ResponseWriter, r *http.Request) {
 			Status:      "running",
 			Ports:       state.Ports{NoVNC: novncPort, Gateway: gatewayPort},
 			CreatedAt:   time.Now(),
+			RuntimeType: runtimeType,
 		}
 		store.Add(inst)
 		if err := store.Save(); err != nil {

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -20,20 +20,28 @@ import (
 
 // instanceResponse is the JSON representation of a single instance.
 type instanceResponse struct {
-	Name             string    `json:"name"`
-	Status           string    `json:"status"`
-	NoVNC            int       `json:"novnc_port"`
-	Gateway          int       `json:"gateway_port"`
-	CreatedAt        time.Time `json:"created_at"`
-	ModelAssetID     string    `json:"model_asset_id,omitempty"`
-	ChannelAssetID   string    `json:"channel_asset_id,omitempty"`
-	CharacterAssetID string    `json:"character_asset_id,omitempty"`
-	ModelName        string    `json:"model_name,omitempty"`
-	ChannelName      string    `json:"channel_name,omitempty"`
-	CharacterName    string    `json:"character_name,omitempty"`
+	Name                string    `json:"name"`
+	Status              string    `json:"status"`
+	NoVNC               int       `json:"novnc_port"`
+	Gateway             int       `json:"gateway_port"`
+	CreatedAt           time.Time `json:"created_at"`
+	ModelAssetID        string    `json:"model_asset_id,omitempty"`
+	ChannelAssetID      string    `json:"channel_asset_id,omitempty"`
+	CharacterAssetID    string    `json:"character_asset_id,omitempty"`
+	ModelName           string    `json:"model_name,omitempty"`
+	ChannelName         string    `json:"channel_name,omitempty"`
+	CharacterName       string    `json:"character_name,omitempty"`
+	RuntimeType         string    `json:"runtime_type"`
+	HermesDashboardPort int       `json:"hermes_dashboard_port,omitempty"`
+	HermesGatewayPort   int       `json:"hermes_gateway_port,omitempty"`
 }
 
 func instanceToResponse(inst state.Instance, assets *state.AssetStore) instanceResponse {
+	runtimeType := inst.RuntimeType
+	if runtimeType == "" {
+		runtimeType = "openclaw"
+	}
+
 	resp := instanceResponse{
 		Name:             inst.Name,
 		Status:           inst.Status,
@@ -43,7 +51,14 @@ func instanceToResponse(inst state.Instance, assets *state.AssetStore) instanceR
 		ModelAssetID:     inst.ModelAssetID,
 		ChannelAssetID:   inst.ChannelAssetID,
 		CharacterAssetID: inst.CharacterAssetID,
+		RuntimeType:      runtimeType,
 	}
+
+	if runtimeType == "hermes" {
+		resp.HermesDashboardPort = inst.Ports.NoVNC
+		resp.HermesGatewayPort = inst.Ports.Gateway
+	}
+
 	if assets != nil {
 		if m := assets.GetModel(inst.ModelAssetID); m != nil {
 			resp.ModelName = m.Name

--- a/internal/web/handlers_configure.go
+++ b/internal/web/handlers_configure.go
@@ -117,6 +117,11 @@ func (s *Server) handleConfigureInstance(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusNotFound, fmt.Sprintf("instance %s not found", name))
 		return
 	}
+	if inst.IsHermes() {
+		writeError(w, http.StatusBadRequest,
+			"Not available for Hermes instances. Use the Hermes Dashboard to configure.")
+		return
+	}
 
 	// Ensure instance is running
 	status, _, _ := container.Status(s.docker, inst.ContainerID)

--- a/internal/web/handlers_image.go
+++ b/internal/web/handlers_image.go
@@ -17,15 +17,18 @@ import (
 
 // handleImageStatus reports whether the sandbox Docker image has been built.
 func (s *Server) handleImageStatus(w http.ResponseWriter, r *http.Request) {
-	exists, err := container.ImageExists(s.docker, s.config.ImageRef())
+	openclawExists, err := container.ImageExists(s.docker, s.config.ImageRef())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	hermesExists, _ := container.ImageExists(s.docker, s.config.HermesImageRef())
 	writeJSON(w, http.StatusOK, map[string]any{
 		"data": map[string]any{
-			"image": s.config.ImageRef(),
-			"built": exists,
+			"image":        s.config.ImageRef(),
+			"built":        openclawExists,
+			"hermes_image": s.config.HermesImageRef(),
+			"hermes_built": hermesExists,
 		},
 	})
 }

--- a/internal/web/handlers_skills.go
+++ b/internal/web/handlers_skills.go
@@ -22,6 +22,11 @@ func (s *Server) handleListInstanceSkills(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusNotFound, fmt.Sprintf("instance %s not found", name))
 		return
 	}
+	if inst.IsHermes() {
+		writeError(w, http.StatusBadRequest,
+			"Not available for Hermes instances. Use the Hermes Dashboard to manage skills.")
+		return
+	}
 
 	status, _, _ := container.Status(s.docker, inst.ContainerID)
 	if status != "running" {
@@ -66,6 +71,11 @@ func (s *Server) handleInstallSkill(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("instance %s not found", name))
 		return
 	}
+	if inst.IsHermes() {
+		writeError(w, http.StatusBadRequest,
+			"Not available for Hermes instances. Use the Hermes Dashboard to manage skills.")
+		return
+	}
 
 	status, _, _ := container.Status(s.docker, inst.ContainerID)
 	if status != "running" {
@@ -96,6 +106,11 @@ func (s *Server) handleUninstallSkill(w http.ResponseWriter, r *http.Request) {
 	inst := store.Get(name)
 	if inst == nil {
 		writeError(w, http.StatusNotFound, fmt.Sprintf("instance %s not found", name))
+		return
+	}
+	if inst.IsHermes() {
+		writeError(w, http.StatusBadRequest,
+			"Not available for Hermes instances. Use the Hermes Dashboard to manage skills.")
 		return
 	}
 

--- a/internal/web/static/css/style.css
+++ b/internal/web/static/css/style.css
@@ -260,8 +260,56 @@ body {
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
 }
 
-.card-running { border-left: 3px solid var(--success); }
-.card-stopped { border-left: 3px solid var(--text-dim); }
+/* OpenClaw instances: orange left accent (matches OpenClaw brand) */
+.card-running.card-openclaw { border-left: 5px solid #f97316; }
+.card-stopped.card-openclaw { border-left: 5px solid rgba(249, 115, 22, 0.3); }
+
+/* Hermes instances: emerald/teal left accent */
+.card-running.card-hermes {
+  border-left: 5px solid #2dd4bf;
+  background: linear-gradient(135deg, var(--surface) 0%, rgba(45, 212, 191, 0.04) 100%);
+}
+.card-stopped.card-hermes {
+  border-left: 5px solid rgba(45, 212, 191, 0.3);
+}
+
+/* Runtime badge in card header */
+.runtime-badge {
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-left: 8px;
+  letter-spacing: 0.03em;
+}
+.runtime-badge-openclaw {
+  background: rgba(249, 115, 22, 0.12);
+  color: #f97316;
+}
+.runtime-badge-hermes {
+  background: rgba(45, 212, 191, 0.12);
+  color: #2dd4bf;
+}
+
+/* Runtime group header in fleet list */
+.runtime-group-header {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 8px 0 12px;
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.runtime-group-header-openclaw { color: #f97316; }
+.runtime-group-header-hermes { color: #2dd4bf; }
+.runtime-group-divider {
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
 
 .card-selected {
   border-color: var(--danger);

--- a/internal/web/static/js/api.js
+++ b/internal/web/static/js/api.js
@@ -20,7 +20,7 @@ async function request(method, path, body) {
 export const api = {
   // Instances
   listInstances:  ()            => request('GET',    '/instances'),
-  createInstances:(count, snapshotName) => request('POST', '/instances', { count, ...(snapshotName && { snapshot_name: snapshotName }) }),
+  createInstances:(count, snapshotName, runtimeType) => request('POST', '/instances', { count, ...(snapshotName && { snapshot_name: snapshotName }), ...(runtimeType && runtimeType !== 'openclaw' && { runtime_type: runtimeType }) }),
   startInstance:  (name)        => request('POST',   `/instances/${encodeURIComponent(name)}/start`),
   stopInstance:   (name)        => request('POST',   `/instances/${encodeURIComponent(name)}/stop`),
   destroyInstance:(name)        => request('DELETE',  `/instances/${encodeURIComponent(name)}`),

--- a/internal/web/static/js/app.js
+++ b/internal/web/static/js/app.js
@@ -154,6 +154,13 @@ function App() {
     }
   };
 
+  const onHermesDashboard = (name) => {
+    const inst = instances.find(i => i.name === name);
+    if (inst && inst.hermes_dashboard_port) {
+      window.open(`http://localhost:${inst.hermes_dashboard_port}/`, '_blank');
+    }
+  };
+
   const onRestartBot = async (name) => {
     if (!confirm(t('confirm.restartBot', name))) return;
     await withPending(name, 'restarting', async () => {
@@ -284,6 +291,7 @@ function App() {
           onConfigure=${(name) => setConfigureName(name)}
           onSnapshot=${onSnapshot}
           onSkills=${(name) => setSkillsName(name)}
+          onHermesDashboard=${onHermesDashboard}
           onCreateClick=${() => setShowCreate(true)}
         />
       `;

--- a/internal/web/static/js/app.js
+++ b/internal/web/static/js/app.js
@@ -104,9 +104,9 @@ function App() {
     try { await fn(); } finally { setPending(p => { const n = { ...p }; delete n[name]; return n; }); }
   };
 
-  const onCreate = async (count, snapshotName) => {
+  const onCreate = async (count, snapshotName, runtime) => {
     try {
-      await api.createInstances(count, snapshotName);
+      await api.createInstances(count, snapshotName, runtime);
       addToast(t('toast.created', count), 'success');
       setShowCreate(false);
     } catch (err) {

--- a/internal/web/static/js/components/create-dialog.js
+++ b/internal/web/static/js/components/create-dialog.js
@@ -6,6 +6,7 @@ export function CreateDialog({ onClose, onCreate }) {
   const { t } = useLang();
   const [count, setCount] = useState(1);
   const [creating, setCreating] = useState(false);
+  const [runtime, setRuntime] = useState('openclaw');
   const [snapshots, setSnapshots] = useState([]);
   const [selectedSnapshot, setSelectedSnapshot] = useState('');
 
@@ -17,7 +18,7 @@ export function CreateDialog({ onClose, onCreate }) {
     e.preventDefault();
     setCreating(true);
     try {
-      await onCreate(count, selectedSnapshot || undefined);
+      await onCreate(count, selectedSnapshot || undefined, runtime);
     } finally {
       setCreating(false);
     }
@@ -33,6 +34,16 @@ export function CreateDialog({ onClose, onCreate }) {
         <form onSubmit=${handleSubmit}>
           <div class="dialog-body">
             <label class="form-label">
+              ${t('create.runtime')}
+              <select class="form-input" value=${runtime} onChange=${(e) => {
+                setRuntime(e.target.value);
+                if (e.target.value === 'hermes') setSelectedSnapshot('');
+              }}>
+                <option value="openclaw">${t('create.runtimeOpenClaw')}</option>
+                <option value="hermes">${t('create.runtimeHermes')}</option>
+              </select>
+            </label>
+            <label class="form-label">
               ${t('create.label')}
               <input
                 type="number"
@@ -47,7 +58,7 @@ export function CreateDialog({ onClose, onCreate }) {
             ${snapshots.length > 0 && html`
               <label class="form-label">
                 ${t('create.snapshot')}
-                <select class="form-input" value=${selectedSnapshot} onChange=${(e) => setSelectedSnapshot(e.target.value)}>
+                <select class="form-input" value=${selectedSnapshot} onChange=${(e) => setSelectedSnapshot(e.target.value)} disabled=${runtime === 'hermes'}>
                   <option value="">${t('create.noSnapshot')}</option>
                   ${snapshots.map(s => html`
                     <option key=${s.id} value=${s.name}>${s.name}</option>

--- a/internal/web/static/js/components/dashboard.js
+++ b/internal/web/static/js/components/dashboard.js
@@ -13,7 +13,7 @@ function SkeletonCard() {
   `;
 }
 
-export function Dashboard({ instances, stats, loading, pending, selected, onToggleSelect, onSelectAll, onBatchDestroy, onStart, onStop, onDestroy, onDesktop, onConsole, onRestartBot, onConfigure, onSnapshot, onSkills, onCreateClick }) {
+export function Dashboard({ instances, stats, loading, pending, selected, onToggleSelect, onSelectAll, onBatchDestroy, onStart, onStop, onDestroy, onDesktop, onConsole, onRestartBot, onConfigure, onSnapshot, onSkills, onHermesDashboard, onCreateClick }) {
   const { t } = useLang();
 
   if (loading) {
@@ -81,6 +81,7 @@ export function Dashboard({ instances, stats, loading, pending, selected, onTogg
               onConfigure=${() => onConfigure(inst.name)}
               onSnapshot=${() => onSnapshot(inst.name)}
               onSkills=${() => onSkills(inst.name)}
+              onHermesDashboard=${() => onHermesDashboard(inst.name)}
             />
           `)}
         </div>

--- a/internal/web/static/js/components/dashboard.js
+++ b/internal/web/static/js/components/dashboard.js
@@ -63,8 +63,10 @@ export function Dashboard({ instances, stats, loading, pending, selected, onTogg
             </label>
           </div>
         `}
-        <div class="dashboard-grid">
-          ${instances.map(inst => html`
+        ${(() => {
+          const openclawInsts = instances.filter(i => i.runtime_type !== 'hermes');
+          const hermesInsts = instances.filter(i => i.runtime_type === 'hermes');
+          const renderCard = (inst) => html`
             <${InstanceCard}
               key=${inst.name}
               instance=${inst}
@@ -83,8 +85,30 @@ export function Dashboard({ instances, stats, loading, pending, selected, onTogg
               onSkills=${() => onSkills(inst.name)}
               onHermesDashboard=${() => onHermesDashboard(inst.name)}
             />
-          `)}
-        </div>
+          `;
+          return html`
+            ${openclawInsts.length > 0 && html`
+              ${hermesInsts.length > 0 && html`
+                <div class="runtime-group-header runtime-group-header-openclaw">
+                  🦞 OpenClaw
+                  <div class="runtime-group-divider"></div>
+                </div>
+              `}
+              <div class="dashboard-grid">
+                ${openclawInsts.map(renderCard)}
+              </div>
+            `}
+            ${hermesInsts.length > 0 && html`
+              <div class="runtime-group-header runtime-group-header-hermes">
+                ☤ Hermes
+                <div class="runtime-group-divider"></div>
+              </div>
+              <div class="dashboard-grid">
+                ${hermesInsts.map(renderCard)}
+              </div>
+            `}
+          `;
+        })()}
       `}
     </div>
   `;

--- a/internal/web/static/js/components/instance-card.js
+++ b/internal/web/static/js/components/instance-card.js
@@ -77,7 +77,7 @@ export function InstanceCard({ instance, stats, pending, selected, onToggleSelec
         ` : ''}
         ${!instance.model_name && !instance.channel_name && !instance.character_name ? html`
           <div class="config-item">
-            <span class="config-value config-unconfigured">${t('card.unconfigured')}</span>
+            <span class="config-value config-unconfigured">${isHermes ? t('card.hermesUnconfigured') : t('card.unconfigured')}</span>
           </div>
         ` : ''}
       </div>

--- a/internal/web/static/js/components/instance-card.js
+++ b/internal/web/static/js/components/instance-card.js
@@ -17,15 +17,15 @@ export function InstanceCard({ instance, stats, pending, selected, onToggleSelec
     : isRunning ? instance.status : t('status.suspended');
 
   return html`
-    <div class="card ${isRunning ? 'card-running' : 'card-stopped'} ${busy ? 'card-busy' : ''} ${selected ? 'card-selected' : ''}">
+    <div class="card ${isRunning ? 'card-running' : 'card-stopped'} ${isHermes ? 'card-hermes' : 'card-openclaw'} ${busy ? 'card-busy' : ''} ${selected ? 'card-selected' : ''}">
       <div class="card-header">
         <div class="card-header-left">
           <input type="checkbox" class="card-checkbox"
             checked=${selected}
             onClick=${(e) => { e.stopPropagation(); onToggleSelect(instance.name); }} />
           <div class="card-name">${instance.name}${isHermes
-            ? html`<span style="font-size:0.65rem;padding:2px 6px;border-radius:4px;margin-left:8px;background:rgba(76,175,80,0.2);color:#4caf50">☤ Hermes</span>`
-            : ''
+            ? html`<span class="runtime-badge runtime-badge-hermes">☤ Hermes</span>`
+            : html`<span class="runtime-badge runtime-badge-openclaw">🦞 OpenClaw</span>`
           }</div>
         </div>
         <span class="status-badge ${isRunning ? 'status-running' : 'status-stopped'}">
@@ -35,14 +35,25 @@ export function InstanceCard({ instance, stats, pending, selected, onToggleSelec
       </div>
 
       <div class="card-ports">
-        <div class="port-item">
-          <span class="port-label">noVNC</span>
-          <span class="port-value">${instance.novnc_port}</span>
-        </div>
-        <div class="port-item">
-          <span class="port-label">Gateway</span>
-          <span class="port-value">${instance.gateway_port}</span>
-        </div>
+        ${isHermes ? html`
+          <div class="port-item">
+            <span class="port-label">Dashboard</span>
+            <span class="port-value">${instance.hermes_dashboard_port}</span>
+          </div>
+          <div class="port-item">
+            <span class="port-label">Gateway</span>
+            <span class="port-value">${instance.hermes_gateway_port}</span>
+          </div>
+        ` : html`
+          <div class="port-item">
+            <span class="port-label">noVNC</span>
+            <span class="port-value">${instance.novnc_port}</span>
+          </div>
+          <div class="port-item">
+            <span class="port-label">Gateway</span>
+            <span class="port-value">${instance.gateway_port}</span>
+          </div>
+        `}
       </div>
 
       <div class="card-config">

--- a/internal/web/static/js/components/instance-card.js
+++ b/internal/web/static/js/components/instance-card.js
@@ -2,9 +2,10 @@ import { html } from '../lib.js';
 import { useLang } from '../i18n.js';
 import { formatBytes } from '../utils.js';
 
-export function InstanceCard({ instance, stats, pending, selected, onToggleSelect, onStart, onStop, onDestroy, onDesktop, onConsole, onRestartBot, onConfigure, onSnapshot, onSkills }) {
+export function InstanceCard({ instance, stats, pending, selected, onToggleSelect, onStart, onStop, onDestroy, onDesktop, onConsole, onRestartBot, onConfigure, onSnapshot, onSkills, onHermesDashboard }) {
   const { t } = useLang();
   const isRunning = instance.status === 'running';
+  const isHermes = instance.runtime_type === 'hermes';
   const cpu = stats?.cpu_percent ?? 0;
   const memUsed = stats?.memory_usage ?? 0;
   const memLimit = stats?.memory_limit ?? 1;
@@ -22,7 +23,10 @@ export function InstanceCard({ instance, stats, pending, selected, onToggleSelec
           <input type="checkbox" class="card-checkbox"
             checked=${selected}
             onClick=${(e) => { e.stopPropagation(); onToggleSelect(instance.name); }} />
-          <div class="card-name">${instance.name}</div>
+          <div class="card-name">${instance.name}${isHermes
+            ? html`<span style="font-size:0.65rem;padding:2px 6px;border-radius:4px;margin-left:8px;background:rgba(76,175,80,0.2);color:#4caf50">☤ Hermes</span>`
+            : ''
+          }</div>
         </div>
         <span class="status-badge ${isRunning ? 'status-running' : 'status-stopped'}">
           <span class="status-dot"></span>
@@ -88,22 +92,27 @@ export function InstanceCard({ instance, stats, pending, selected, onToggleSelec
 
       <div class="card-actions">
         ${isRunning ? html`
-          <button class="btn btn-sm btn-desktop" onClick=${onDesktop} disabled=${busy}>${t('card.desktop')}</button>
-          <button class="btn btn-sm btn-desktop" onClick=${onConsole} disabled=${busy}>${t('card.controlPanel')}</button>
-          <button class="btn btn-sm btn-configure" onClick=${onConfigure} disabled=${busy}>
-            ${pending === 'configuring' ? t('action.configuring') : t('card.configure')}
-          </button>
-          <button class="btn btn-sm btn-configure" onClick=${onSkills} disabled=${busy}>
-            ${t('card.skills')}
-          </button>
-          ${instance.model_name && html`
-            <button class="btn btn-sm btn-snapshot" onClick=${onSnapshot} disabled=${busy}>
-              ${t('card.snapshot')}
+          ${!isHermes && html`
+            <button class="btn btn-sm btn-desktop" onClick=${onDesktop} disabled=${busy}>${t('card.desktop')}</button>
+            <button class="btn btn-sm btn-desktop" onClick=${onConsole} disabled=${busy}>${t('card.controlPanel')}</button>
+            <button class="btn btn-sm btn-configure" onClick=${onConfigure} disabled=${busy}>
+              ${pending === 'configuring' ? t('action.configuring') : t('card.configure')}
+            </button>
+            <button class="btn btn-sm btn-configure" onClick=${onSkills} disabled=${busy}>
+              ${t('card.skills')}
+            </button>
+            ${instance.model_name && html`
+              <button class="btn btn-sm btn-snapshot" onClick=${onSnapshot} disabled=${busy}>
+                ${t('card.snapshot')}
+              </button>
+            `}
+            <button class="btn btn-sm btn-reset" onClick=${onRestartBot} disabled=${busy}>
+              ${pending === 'restarting' ? t('action.restarting') : t('card.restartBot')}
             </button>
           `}
-          <button class="btn btn-sm btn-reset" onClick=${onRestartBot} disabled=${busy}>
-            ${pending === 'restarting' ? t('action.restarting') : t('card.restartBot')}
-          </button>
+          ${isHermes && html`
+            <button class="btn btn-sm btn-desktop" onClick=${onHermesDashboard} disabled=${busy}>${t('card.hermesDashboard')}</button>
+          `}
           <button class="btn btn-sm btn-warning" onClick=${onStop} disabled=${busy}>
             ${pending === 'stopping' ? t('action.stopping') : t('card.suspend')}
           </button>

--- a/internal/web/static/js/i18n.js
+++ b/internal/web/static/js/i18n.js
@@ -26,6 +26,7 @@ const messages = {
     'card.resume':           '▶ Resume',
     'card.destroy':          '🗑 Destroy',
     'card.unconfigured':     'Not configured',
+    'card.hermesUnconfigured': 'Configure in Dashboard →',
     'status.suspended':      'suspended',
 
     'create.title':          'Create Instances',
@@ -254,6 +255,7 @@ const messages = {
     'card.resume':           '▶ 复位',
     'card.destroy':          '🗑 销毁',
     'card.unconfigured':     '未配置',
+    'card.hermesUnconfigured': '在 Dashboard 中配置 →',
     'status.suspended':      '挂起中',
 
     'create.title':          '创建实例',

--- a/internal/web/static/js/i18n.js
+++ b/internal/web/static/js/i18n.js
@@ -156,6 +156,7 @@ const messages = {
     'skills.searchHint':     'Search 13,000+ community skills on ClawHub',
     'skills.requiresRunning':'Instance must be running to manage skills.',
     'card.skills':           'Skills',
+    'card.hermesDashboard':  '⚕ Dashboard',
 
     // Characters
     'sidebar.characters':    'Character Config',
@@ -383,6 +384,7 @@ const messages = {
     'skills.searchHint':     '在 ClawHub 搜索 13,000+ 社区技能',
     'skills.requiresRunning':'实例必须处于运行状态才能管理技能。',
     'card.skills':           '技能',
+    'card.hermesDashboard':  '⚕ 控制台',
 
     // Characters
     'sidebar.characters':    'Character 配置',

--- a/internal/web/static/js/i18n.js
+++ b/internal/web/static/js/i18n.js
@@ -29,6 +29,9 @@ const messages = {
     'status.suspended':      'suspended',
 
     'create.title':          'Create Instances',
+    'create.runtime':        'Runtime',
+    'create.runtimeOpenClaw':'🦞 OpenClaw',
+    'create.runtimeHermes':  '☤ Hermes',
     'create.label':          'Number of instances',
     'create.hint':           'Each instance uses ~4 GB RAM and 2 CPU cores.',
     'create.cancel':         'Cancel',
@@ -253,6 +256,9 @@ const messages = {
     'status.suspended':      '挂起中',
 
     'create.title':          '创建实例',
+    'create.runtime':        '运行时',
+    'create.runtimeOpenClaw':'🦞 OpenClaw',
+    'create.runtimeHermes':  '☤ Hermes',
     'create.label':          '实例数量',
     'create.hint':           '每个实例约占用 4 GB 内存和 2 个 CPU 核心。',
     'create.cancel':         '取消',


### PR DESCRIPTION
## Summary

### Hermes Integration (lifecycle-only)
- Create Hermes instances alongside OpenClaw from Dashboard or CLI
- Unified Fleet list with runtime grouping (🦞 OpenClaw / ☤ Hermes)
- Hermes containers run dashboard (9119) + gateway (3000) simultaneously
- Instance cards show runtime-appropriate badges, ports, and buttons
- OpenClaw-only operations (Configure, Skills, Restart Bot) rejected for Hermes with helpful message
- Hermes card shows "Configure in Dashboard →" instead of "Not configured"

### `clawfleet shell` command
- `clawfleet shell <name>` opens interactive terminal inside any instance
- Hermes: launches Hermes TUI (interactive chat)
- OpenClaw: opens bash shell as node user

### OpenClaw version bump
- 2026.4.14 → 2026.4.15 (tested: build, configure, health, chat compatibility — all pass)

## Files changed (16)
- `internal/state/store.go` — Instance.RuntimeType field + IsHermes()
- `internal/config/config.go` — HermesConfig + defaults
- `internal/container/manager.go` — Runtime-aware ports/volumes/entrypoint
- `internal/web/handlers.go` — Create with runtime_type, handler guards, response fields
- `internal/web/handlers_configure.go` — Reject configure for Hermes
- `internal/web/handlers_skills.go` — Reject skills ops for Hermes
- `internal/web/handlers_image.go` — Hermes image status
- `internal/cli/shell.go` — New: interactive shell command
- `internal/cli/root.go` — Register shell command
- `internal/version/version.go` — OpenClaw 4.15
- Frontend: create-dialog, instance-card, dashboard, app.js, api.js, i18n.js, style.css

🤖 Generated with [Claude Code](https://claude.com/claude-code)