### PR TITLE
feat: Hermes Configure automation + runtime-prefixed naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,12 +148,28 @@ When researching an external technology (framework, tool, protocol, or platform)
 
 The output of any tech research should be a clear recommendation: compete / integrate / borrow / ignore — with reasoning.
 
-### Verify Before Handoff
-- After fixing a bug or implementing a feature that affects API/server behavior, smoke-test the change yourself (e.g. `curl` requests to the local server, `docker exec` commands) before asking the user to verify on the UI.
+### External Component Spec-First
+ClawFleet is an infrastructure-layer product. Every time we integrate a new runtime (e.g. Hermes Agent) or depend on a new external tool, we must first build a thorough understanding of that component's internals and document it in a spec — before writing any integration code:
+
+1. **Read the source code** of the subsystem being integrated (auth, config, provider resolution, credential storage). The source is always available — inside containers, in repos, or in installed packages.
+2. **Map the complete data flow**: where credentials are read, how providers are resolved, what env vars are checked, what config keys are honored, and in what priority order.
+3. **Document findings in the spec** with concrete details: exact provider names, env var names, config paths, resolution fallback chains. No assumptions carried over from other systems.
+4. **Validate manually in the target environment** (e.g. `docker exec` into the container, set config, test the API call) before writing any Go/JS code.
+
+Skipping this step and guessing from analogies with other systems (e.g. assuming Hermes works like OpenClaw) leads to repeated debugging cycles that waste engineering time and user patience.
+
+### Self-Test to Completion Before Handoff
+The user's role is to set goals, review designs, and do final acceptance testing — not to participate in debug iterations. The correct human-in-the-loop workflow is:
+
+1. **Set a clear success criterion** (e.g. "DM the bot, get an LLM-generated reply").
+2. **Implement and self-test end-to-end** until that criterion is met. Self-testing means: build → configure via API → verify config in container → trigger the exact user flow (send a message, check logs for success) → confirm the full chain works.
+3. **Only then present to the user for acceptance**. If the user finds a bug, fix it and self-test the fix before asking them to re-test.
+
+Never ask the user to "try it and see" as a substitute for your own testing. Every handoff to the user must be a confident "this works, please verify" — not "I think this might work, let me know".
 
 ## Growth Strategy Sync
 
-<!-- strategy-bulletin-version: 2 -->
+<!-- strategy-bulletin-version: 8 -->
 
 All Marketer-Sessions (growth, content, distribution) MUST re-read `growth/STRATEGY_BULLETIN.md` before every action cycle (writing content, publishing, making distribution decisions). This file contains the live strategy, target user definition, active decisions, and constraints. It is updated by the lead Marketer-Session; the version comment above is bumped on each update to trigger CLAUDE.md change notifications to all running sessions.
 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 reset:
-	@echo "==> Destroying all claw instances..."
+	@echo "==> Destroying all instances..."
 	@if [ -f $(BUILD_DIR)/$(BINARY) ]; then \
 		echo y | $(BUILD_DIR)/$(BINARY) destroy --purge all 2>/dev/null || true; \
 		$(BUILD_DIR)/$(BINARY) dashboard stop 2>/dev/null || true; \

--- a/internal/cli/configure.go
+++ b/internal/cli/configure.go
@@ -13,11 +13,11 @@ var configureCmd = &cobra.Command{
 	Use:   "configure <name>",
 	Short: "Configure an OpenClaw instance with LLM provider and chat channel",
 	Args:  cobra.ExactArgs(1),
-	Example: `  clawfleet configure claw-1 \
+	Example: `  clawfleet configure openclaw-1 \
     --provider anthropic --api-key sk-ant-... --model claude-sonnet-4-6 \
     --channel telegram --channel-token 123456:ABC...
 
-  clawfleet configure claw-1 \
+  clawfleet configure openclaw-1 \
     --provider openai --api-key sk-... --model gpt-5.4 \
     --channel slack --channel-token xoxb-... --channel-app-token xapp-...`,
 	RunE: runConfigure,

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -21,7 +21,7 @@ var fromSnapshotFlag string
 
 var createCmd = &cobra.Command{
 	Use:     "create <N>",
-	Short:   "Create N isolated OpenClaw instances",
+	Short:   "Create N isolated instances",
 	Args:    cobra.ExactArgs(1),
 	Example: "  clawfleet create 3\n  clawfleet create 1\n  clawfleet create 3 --pull",
 	RunE:    runCreate,
@@ -91,7 +91,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	created := 0
 	firstName := ""
 	for i := 0; i < n; i++ {
-		name := store.NextName(cfg.Naming.Prefix)
+		name := store.NextName(config.NamingPrefix("openclaw"))
 		if firstName == "" {
 			firstName = name
 		}

--- a/internal/cli/desktop.go
+++ b/internal/cli/desktop.go
@@ -11,9 +11,9 @@ import (
 
 var desktopCmd = &cobra.Command{
 	Use:     "desktop <name>",
-	Short:   "Open a claw's noVNC desktop in the browser",
+	Short:   "Open an instance's noVNC desktop in the browser",
 	Args:    cobra.ExactArgs(1),
-	Example: "  clawfleet desktop claw-1",
+	Example: "  clawfleet desktop openclaw-1",
 	RunE:    runDesktop,
 }
 

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -21,9 +21,9 @@ var (
 
 var destroyCmd = &cobra.Command{
 	Use:     "destroy <name|all>",
-	Short:   "Destroy a claw instance (data is kept by default)",
+	Short:   "Destroy an instance (data is kept by default)",
 	Args:    cobra.ExactArgs(1),
-	Example: "  clawfleet destroy claw-1\n  clawfleet destroy all --purge\n  clawfleet destroy claw-1 -f --purge",
+	Example: "  clawfleet destroy openclaw-1\n  clawfleet destroy all --purge\n  clawfleet destroy hermes-1 -f --purge",
 	RunE:    runDestroy,
 }
 

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -14,9 +14,9 @@ var logsFollow bool
 
 var logsCmd = &cobra.Command{
 	Use:     "logs <name>",
-	Short:   "View container logs for a claw instance",
+	Short:   "View container logs for an instance",
 	Args:    cobra.ExactArgs(1),
-	Example: "  clawfleet logs claw-1\n  clawfleet logs claw-1 -f",
+	Example: "  clawfleet logs hermes-1\n  clawfleet logs openclaw-1 -f",
 	RunE:    runLogs,
 }
 

--- a/internal/cli/restart.go
+++ b/internal/cli/restart.go
@@ -11,9 +11,9 @@ import (
 
 var restartCmd = &cobra.Command{
 	Use:     "restart <name|all>",
-	Short:   "Restart a claw instance (stop then start)",
+	Short:   "Restart an instance (stop then start)",
 	Args:    cobra.ExactArgs(1),
-	Example: "  clawfleet restart claw-1\n  clawfleet restart all",
+	Example: "  clawfleet restart openclaw-1\n  clawfleet restart all",
 	RunE:    runRestart,
 }
 

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -20,7 +20,7 @@ var shellCmd = &cobra.Command{
 For Hermes instances, this launches the Hermes interactive CLI (TUI).
 For OpenClaw instances, this opens a bash shell.`,
 	Args:    cobra.ExactArgs(1),
-	Example: "  clawfleet shell claw-1",
+	Example: "  clawfleet shell hermes-1",
 	RunE:    runShell,
 }
 

--- a/internal/cli/snapshot_save.go
+++ b/internal/cli/snapshot_save.go
@@ -19,7 +19,7 @@ var snapshotSaveCmd = &cobra.Command{
 	Use:     "save <instance-name>",
 	Short:   "Save a snapshot of an instance",
 	Args:    cobra.ExactArgs(1),
-	Example: "  clawfleet snapshot save claw-1\n  clawfleet snapshot save claw-1 --name my-snapshot --description \"Production config\"",
+	Example: "  clawfleet snapshot save openclaw-1\n  clawfleet snapshot save openclaw-1 --name my-snapshot --description \"Production config\"",
 	RunE:    runSnapshotSave,
 }
 

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -11,9 +11,9 @@ import (
 
 var startCmd = &cobra.Command{
 	Use:     "start <name|all>",
-	Short:   "Start a stopped claw instance",
+	Short:   "Start a stopped instance",
 	Args:    cobra.ExactArgs(1),
-	Example: "  clawfleet start claw-1\n  clawfleet start all",
+	Example: "  clawfleet start openclaw-1\n  clawfleet start all",
 	RunE:    runStart,
 }
 

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -11,9 +11,9 @@ import (
 
 var stopCmd = &cobra.Command{
 	Use:     "stop <name|all>",
-	Short:   "Stop a running claw instance",
+	Short:   "Stop a running instance",
 	Args:    cobra.ExactArgs(1),
-	Example: "  clawfleet stop claw-1\n  clawfleet stop all",
+	Example: "  clawfleet stop hermes-1\n  clawfleet stop all",
 	RunE:    runStop,
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,7 +16,7 @@ const (
 	DefaultGatewayBase  = 18789
 	DefaultMemoryLimit  = "4g"
 	DefaultCPULimit     = 2.0
-	DefaultNamingPrefix = "claw"
+	DefaultNamingPrefix = "claw" // legacy; new instances use runtime-prefixed names
 
 	DefaultHermesImageName = "nousresearch/hermes-agent"
 	DefaultHermesImageTag  = "latest"
@@ -55,6 +55,15 @@ type NamingConfig struct {
 type HermesConfig struct {
 	ImageName string `yaml:"image_name"`
 	ImageTag  string `yaml:"image_tag"`
+}
+
+// NamingPrefix returns the instance name prefix for the given runtime type.
+// New instances are named "openclaw-N" or "hermes-N" based on runtime.
+func NamingPrefix(runtimeType string) string {
+	if runtimeType == "hermes" {
+		return "hermes"
+	}
+	return "openclaw"
 }
 
 func (c *Config) ImageRef() string {

--- a/internal/container/configure.go
+++ b/internal/container/configure.go
@@ -280,7 +280,9 @@ func Configure(cli *docker.Client, p ConfigureParams) error {
 			return fmt.Errorf("waiting for Slack gateway start: %w", err)
 		}
 	} else if p.Channel != "" && p.ChannelToken != "" {
-		// Telegram/Discord: start gateway → channels add → stop → policies → restart.
+		// Telegram/Discord: start gateway → channels add → policies (no stop/restart).
+		// channels add MUST run with gateway online so the Discord client initializes
+		// properly. Policies are applied via hot-reload — no gateway restart needed.
 		if err := dockerExecAs(cli, p.ContainerID, "root", []string{
 			"supervisorctl", "start", "openclaw", "gateway-bridge",
 		}); err != nil {
@@ -290,16 +292,27 @@ func Configure(cli *docker.Client, p ConfigureParams) error {
 			return fmt.Errorf("waiting for gateway: %w", err)
 		}
 
-		if err := dockerExecAs(cli, p.ContainerID, "node", []string{
-			"openclaw", "channels", "add",
-			"--channel", pluginName,
-			"--token", p.ChannelToken,
-		}); err != nil {
-			return fmt.Errorf("channels add: %w", err)
+		// channels add with retry — ConfigMutationConflictError can occur when
+		// the gateway's hot-reload races with the config write.
+		var addErr error
+		for attempt := 0; attempt < 3; attempt++ {
+			addErr = dockerExecAs(cli, p.ContainerID, "node", []string{
+				"openclaw", "channels", "add",
+				"--channel", pluginName,
+				"--token", p.ChannelToken,
+			})
+			if addErr == nil {
+				break
+			}
+			time.Sleep(2 * time.Second)
+		}
+		if addErr != nil {
+			return fmt.Errorf("channels add: %w", addErr)
 		}
 
-		// Stop gateway before writing policy changes so they are
-		// applied offline — no hot-reload with incomplete intermediate config.
+		// Stop gateway before writing policies. Multiple rapid config set calls
+		// while gateway is running trigger cascading hot-reloads → restart loop.
+		// Writing all policies offline then starting once avoids this entirely.
 		if err := dockerExecAs(cli, p.ContainerID, "root", []string{
 			"supervisorctl", "stop", "openclaw",
 		}); err != nil {
@@ -321,14 +334,15 @@ func Configure(cli *docker.Client, p ConfigureParams) error {
 			}
 		}
 
-		// Start gateway with the complete, final config.
+		// Final start with complete config. channels add already initialized
+		// the Discord client state; this restart picks up all policies cleanly.
 		if err := dockerExecAs(cli, p.ContainerID, "root", []string{
 			"supervisorctl", "start", "openclaw", "gateway-bridge",
 		}); err != nil {
 			return fmt.Errorf("supervisorctl start after policies: %w", err)
 		}
 		if err := waitForGateway(cli, p.ContainerID, 30*time.Second); err != nil {
-			return fmt.Errorf("waiting for gateway restart: %w", err)
+			return fmt.Errorf("waiting for gateway: %w", err)
 		}
 	} else if p.Channel == "" {
 		// No channel — just start the gateway with model-only config.
@@ -655,6 +669,169 @@ func injectCodexAuthProfile(cli *docker.Client, containerID, accessToken, refres
 	return dockerExecAs(cli, containerID, "node", []string{
 		"bash", "-c", fmt.Sprintf("cat > %s << 'CLAWFLEET_EOF'\n%s\nCLAWFLEET_EOF", authPath, string(data)),
 	})
+}
+
+// HermesConfigureParams holds Hermes-specific configuration parameters.
+type HermesConfigureParams struct {
+	ContainerID  string
+	Provider     string // e.g. "openai", "openai-codex", "anthropic"
+	APIKey       string // API key or OAuth access token
+	Model        string // e.g. "gpt-5.4-mini"
+	Channel      string // e.g. "discord", "telegram"
+	ChannelToken string // bot token
+	// OAuth fields (openai-codex)
+	OAuthRefresh   string
+	OAuthExpires   int64
+	OAuthAccountID string
+}
+
+// ConfigureHermes configures a Hermes Agent instance by writing .env and config.yaml
+// inside the container, then restarting the gateway process.
+func ConfigureHermes(cli *docker.Client, p HermesConfigureParams) error {
+	const envPath = "/opt/data/.env"
+	const configPath = "/opt/data/config.yaml"
+
+	// Build .env additions.
+	// Hermes uses provider-specific env vars (not OPENAI_API_KEY for everything).
+	// OpenAI has no native provider in Hermes — we use model.api_key in config.yaml instead.
+	// Provider may be empty for channel-only configuration.
+	var envLines []string
+
+	switch p.Provider {
+	case "openai-codex":
+		return fmt.Errorf("openai-codex (ChatGPT subscription) is not supported for Hermes instances. Please use a standard OpenAI API key model instead")
+	case "": // Channel-only config — skip model credentials
+	case "openai":
+		// OpenAI has no native Hermes provider. API key is set via model.api_key below.
+	case "anthropic":
+		envLines = append(envLines, fmt.Sprintf("ANTHROPIC_API_KEY=%s", p.APIKey))
+	case "google":
+		envLines = append(envLines, fmt.Sprintf("GEMINI_API_KEY=%s", p.APIKey))
+	case "deepseek":
+		envLines = append(envLines, fmt.Sprintf("DEEPSEEK_API_KEY=%s", p.APIKey))
+	}
+
+	// Channel credentials
+	if p.Channel == "discord" && p.ChannelToken != "" {
+		envLines = append(envLines, fmt.Sprintf("DISCORD_BOT_TOKEN=%s", p.ChannelToken))
+	} else if p.Channel == "telegram" && p.ChannelToken != "" {
+		envLines = append(envLines, fmt.Sprintf("TELEGRAM_BOT_TOKEN=%s", p.ChannelToken))
+	} else if p.Channel == "slack" && p.ChannelToken != "" {
+		envLines = append(envLines, fmt.Sprintf("SLACK_BOT_TOKEN=%s", p.ChannelToken))
+	}
+
+	// Allow all users by default (ClawFleet manages access at the container level)
+	envLines = append(envLines, "GATEWAY_ALLOW_ALL_USERS=true")
+
+	// Write .env additions: remove any previous ClawFleet block, then append fresh.
+	if len(envLines) > 0 {
+		// Remove old ClawFleet-injected block (everything from the marker to EOF).
+		_ = dockerExecAs(cli, p.ContainerID, "", []string{
+			"sed", "-i", "/^# Configured by ClawFleet$/,$d", envPath,
+		})
+		envBlock := "\n# Configured by ClawFleet\n" + strings.Join(envLines, "\n") + "\n"
+		if err := dockerExecAs(cli, p.ContainerID, "", []string{
+			"bash", "-c", fmt.Sprintf("cat >> %s << 'CLAWFLEET_EOF'\n%sCLAWFLEET_EOF", envPath, envBlock),
+		}); err != nil {
+			return fmt.Errorf("writing .env: %w", err)
+		}
+	}
+
+	// Set model in config.yaml via hermes CLI.
+	// Hermes provider mapping:
+	//   ClawFleet "openai"    → Hermes "openrouter" + model.base_url=api.openai.com + model.api_key
+	//   ClawFleet "anthropic" → Hermes "anthropic"  + ANTHROPIC_API_KEY env
+	//   ClawFleet "google"    → Hermes "gemini"     + GEMINI_API_KEY env
+	//   ClawFleet "deepseek"  → Hermes "deepseek"   + DEEPSEEK_API_KEY env
+	if p.Model != "" {
+		model := p.Model
+
+		var hermesProvider, baseURL, apiKey string
+		switch p.Provider {
+		case "openai":
+			// Hermes has no native "openai" provider. Use "custom" provider with
+			// direct API endpoint and key set in config.yaml. Verified working.
+			hermesProvider = "custom"
+			baseURL = "https://api.openai.com/v1"
+			apiKey = p.APIKey
+		case "anthropic":
+			hermesProvider = "anthropic"
+			if !strings.Contains(model, "/") {
+				model = "anthropic/" + model
+			}
+		case "google":
+			hermesProvider = "gemini"
+			if !strings.Contains(model, "/") {
+				model = "google/" + model
+			}
+		case "deepseek":
+			hermesProvider = "deepseek"
+			if !strings.Contains(model, "/") {
+				model = "deepseek/" + model
+			}
+		}
+
+		configCmds := []struct{ key, val string }{
+			{"model.default", model},
+			{"model.provider", hermesProvider},
+			{"model.base_url", baseURL},
+			{"model.api_key", apiKey},
+		}
+		for _, c := range configCmds {
+			if err := dockerExecAs(cli, p.ContainerID, "", []string{
+				"bash", "-c",
+				fmt.Sprintf("source /opt/hermes/.venv/bin/activate && hermes config set %s '%s'", c.key, c.val),
+			}); err != nil {
+				return fmt.Errorf("setting %s: %w", c.key, err)
+			}
+		}
+	}
+
+	// Enable the channel platform in config.yaml
+	if p.Channel != "" {
+		platform := p.Channel
+		if err := dockerExecAs(cli, p.ContainerID, "", []string{
+			"bash", "-c",
+			fmt.Sprintf("source /opt/hermes/.venv/bin/activate && hermes config set gateway.platforms.%s.enabled true", platform),
+		}); err != nil {
+			return fmt.Errorf("enabling %s platform: %w", platform, err)
+		}
+	}
+
+	// Channel-only mode: if no model was configured by ClawFleet but the user
+	// has Codex credentials from the Hermes Dashboard, auto-set the model provider
+	// so the bot can actually respond. Without this, Codex login stores credentials
+	// but model.provider stays "auto" and Hermes fails to find a provider.
+	if p.Provider == "" {
+		authCheck, _ := dockerExecOutputAs(cli, p.ContainerID, "", []string{
+			"bash", "-c",
+			`python3 -c "import json; d=json.load(open('/opt/data/auth.json')); print('codex' if d.get('credential_pool',{}).get('openai-codex') else 'none')"`,
+		})
+		if strings.TrimSpace(authCheck) == "codex" {
+			// Codex credentials exist — set provider and a default model.
+			for _, c := range []struct{ key, val string }{
+				{"model.provider", "openai-codex"},
+				{"model.default", "gpt-5.4-mini"},
+			} {
+				_ = dockerExecAs(cli, p.ContainerID, "", []string{
+					"bash", "-c",
+					fmt.Sprintf("source /opt/hermes/.venv/bin/activate && hermes config set %s '%s'", c.key, c.val),
+				})
+			}
+		}
+	}
+
+	// Restart the container to pick up new .env and config changes.
+	// The entrypoint will re-launch both dashboard and gateway.
+	if err := cli.RestartContainer(p.ContainerID, 10); err != nil {
+		return fmt.Errorf("restarting container: %w", err)
+	}
+
+	// Wait for gateway to come up (Hermes gateway doesn't have a /health endpoint
+	// on a known port from outside, so we just wait a fixed duration)
+	time.Sleep(15 * time.Second)
+
+	return nil
 }
 
 // waitForGateway polls the gateway health endpoint until it responds or timeout.

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -174,7 +174,7 @@ func (s *Server) handleCreateInstances(w http.ResponseWriter, r *http.Request) {
 
 	created := make([]instanceResponse, 0, req.Count)
 	for i := 0; i < req.Count; i++ {
-		name := store.NextName(cfg.Naming.Prefix)
+		name := store.NextName(config.NamingPrefix(runtimeType))
 		usedPorts := store.UsedPorts()
 
 		novncPort, err := port.FindAvailable(cfg.Ports.NoVNCBase, usedPorts)

--- a/internal/web/handlers_configure.go
+++ b/internal/web/handlers_configure.go
@@ -45,32 +45,32 @@ func (s *Server) handleConfigureInstance(w http.ResponseWriter, r *http.Request)
 	}
 
 	var assetsStore *state.AssetStore
-	if req.ModelAssetID != "" {
-		// Standard mode with asset IDs: resolve them to actual config values.
+	if req.ModelAssetID != "" || req.ChannelAssetID != "" {
+		// Resolve asset IDs to actual config values.
 		assets, err := s.loadAssets()
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 
-		model := assets.GetModel(req.ModelAssetID)
-		if model == nil {
-			writeError(w, http.StatusBadRequest, "model asset not found")
-			return
-		}
-		if !model.Validated {
-			writeError(w, http.StatusBadRequest, "model asset has not been validated")
-			return
+		if req.ModelAssetID != "" {
+			model := assets.GetModel(req.ModelAssetID)
+			if model == nil {
+				writeError(w, http.StatusBadRequest, "model asset not found")
+				return
+			}
+			if !model.Validated {
+				writeError(w, http.StatusBadRequest, "model asset has not been validated")
+				return
+			}
+			req.Provider = model.Provider
+			req.APIKey = model.APIKey
+			req.Model = model.Model
+			req.OAuthRefresh = model.OAuthRefresh
+			req.OAuthExpires = model.OAuthExpires
+			req.OAuthAccountID = model.OAuthAccountID
 		}
 
-		req.Provider = model.Provider
-		req.APIKey = model.APIKey
-		req.Model = model.Model
-		req.OAuthRefresh = model.OAuthRefresh
-		req.OAuthExpires = model.OAuthExpires
-		req.OAuthAccountID = model.OAuthAccountID
-
-		// Handle channel asset
 		if req.ChannelAssetID != "" {
 			channel := assets.GetChannel(req.ChannelAssetID)
 			if channel == nil {
@@ -90,7 +90,27 @@ func (s *Server) handleConfigureInstance(w http.ResponseWriter, r *http.Request)
 		assetsStore = assets
 	}
 
-	if req.Provider == "" || req.APIKey == "" {
+	// For OpenClaw, model (provider + api_key) is required.
+	// For Hermes, model is optional — user may configure only a channel
+	// (model may already be set via the Hermes native Dashboard).
+	if req.ModelAssetID == "" && req.Provider == "" {
+		// No model asset and no direct provider — check if this is a Hermes channel-only config
+		store0, err := s.loadStore()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		inst0 := store0.Get(name)
+		if inst0 == nil || !inst0.IsHermes() {
+			writeError(w, http.StatusBadRequest, "provider and api_key are required")
+			return
+		}
+		// Hermes channel-only: must have a channel
+		if req.ChannelAssetID == "" && req.Channel == "" {
+			writeError(w, http.StatusBadRequest, "either model or channel is required")
+			return
+		}
+	} else if req.Provider == "" || req.APIKey == "" {
 		writeError(w, http.StatusBadRequest, "provider and api_key are required")
 		return
 	}
@@ -117,13 +137,7 @@ func (s *Server) handleConfigureInstance(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusNotFound, fmt.Sprintf("instance %s not found", name))
 		return
 	}
-	if inst.IsHermes() {
-		writeError(w, http.StatusBadRequest,
-			"Not available for Hermes instances. Use the Hermes Dashboard to configure.")
-		return
-	}
-
-	// Ensure instance is running
+	// Ensure instance is running before configuration.
 	status, _, _ := container.Status(s.docker, inst.ContainerID)
 	if status != "running" {
 		if err := container.Start(s.docker, inst.ContainerID); err != nil {
@@ -134,53 +148,87 @@ func (s *Server) handleConfigureInstance(w http.ResponseWriter, r *http.Request)
 		_ = store.Save()
 	}
 
-	// Resolve bot display name from the channel platform for text @mention detection.
-	// Lark/Feishu doesn't support programmatic bot name resolution via API,
-	// so we skip it — text @mention detection is not needed for Feishu
-	// (it uses native platform mentions).
-	var botName string
-	if req.Channel != "" && req.Channel != "lark" && req.ChannelToken != "" {
-		botName = resolveBotName(req.Channel, req.ChannelToken)
-	}
+	if inst.IsHermes() {
+		// Hermes supports discord, telegram, and slack channels.
+		if req.Channel != "" && req.Channel != "discord" && req.Channel != "telegram" && req.Channel != "slack" {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("Hermes does not support %s channel", req.Channel))
+			return
+		}
 
-	// Resolve character asset into SoulParams so it's injected before gateway starts.
-	// Include roster (teammates) so the bot knows about its fleet.
-	var soul *container.SoulParams
-	if req.CharacterAssetID != "" {
-		assets, loadErr := s.loadAssets()
-		if loadErr == nil {
-			if ch := assets.GetCharacter(req.CharacterAssetID); ch != nil {
-				soul = &container.SoulParams{
-					Name:       ch.Name,
-					Bio:        ch.Bio,
-					Lore:       ch.Lore,
-					Style:      ch.Style,
-					Topics:     ch.Topics,
-					Adjectives: ch.Adjectives,
-					Teammates:  buildRoster(name, store, assets),
+		if err := container.ConfigureHermes(s.docker, container.HermesConfigureParams{
+			ContainerID:    inst.ContainerID,
+			Provider:       req.Provider,
+			APIKey:         req.APIKey,
+			Model:          req.Model,
+			Channel:        req.Channel,
+			ChannelToken:   req.ChannelToken,
+			OAuthRefresh:   req.OAuthRefresh,
+			OAuthExpires:   req.OAuthExpires,
+			OAuthAccountID: req.OAuthAccountID,
+		}); err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("configure failed: %v", err))
+			return
+		}
+	} else {
+		// OpenClaw configuration path.
+
+		// Resolve bot display name from the channel platform for text @mention detection.
+		// Lark/Feishu doesn't support programmatic bot name resolution via API,
+		// so we skip it — text @mention detection is not needed for Feishu
+		// (it uses native platform mentions).
+		var botName string
+		if req.Channel != "" && req.Channel != "lark" && req.ChannelToken != "" {
+			botName = resolveBotName(req.Channel, req.ChannelToken)
+		}
+
+		// Resolve character asset into SoulParams so it's injected before gateway starts.
+		// Include roster (teammates) so the bot knows about its fleet.
+		var soul *container.SoulParams
+		if req.CharacterAssetID != "" {
+			assets, loadErr := s.loadAssets()
+			if loadErr == nil {
+				if ch := assets.GetCharacter(req.CharacterAssetID); ch != nil {
+					soul = &container.SoulParams{
+						Name:       ch.Name,
+						Bio:        ch.Bio,
+						Lore:       ch.Lore,
+						Style:      ch.Style,
+						Topics:     ch.Topics,
+						Adjectives: ch.Adjectives,
+						Teammates:  buildRoster(name, store, assets),
+					}
 				}
 			}
 		}
-	}
 
-	if err := container.Configure(s.docker, container.ConfigureParams{
-		ContainerID:     inst.ContainerID,
-		Provider:        req.Provider,
-		APIKey:          req.APIKey,
-		Model:           req.Model,
-		Channel:         req.Channel,
-		ChannelToken:    req.ChannelToken,
-		ChannelAppToken: req.ChannelAppToken,
-		AppID:           req.AppID,
-		AppSecret:       req.AppSecret,
-		BotName:         botName,
-		Soul:            soul,
-		OAuthRefresh:    req.OAuthRefresh,
-		OAuthExpires:    req.OAuthExpires,
-		OAuthAccountID:  req.OAuthAccountID,
-	}); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("configure failed: %v", err))
-		return
+		if err := container.Configure(s.docker, container.ConfigureParams{
+			ContainerID:     inst.ContainerID,
+			Provider:        req.Provider,
+			APIKey:          req.APIKey,
+			Model:           req.Model,
+			Channel:         req.Channel,
+			ChannelToken:    req.ChannelToken,
+			ChannelAppToken: req.ChannelAppToken,
+			AppID:           req.AppID,
+			AppSecret:       req.AppSecret,
+			BotName:         botName,
+			Soul:            soul,
+			OAuthRefresh:    req.OAuthRefresh,
+			OAuthExpires:    req.OAuthExpires,
+			OAuthAccountID:  req.OAuthAccountID,
+		}); err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("configure failed: %v", err))
+			return
+		}
+
+		// Refresh teammates' SOUL.md so their roster includes this instance.
+		if req.CharacterAssetID != "" {
+			if refreshAssets, err := s.loadAssets(); err == nil {
+				if refreshStore, err := s.loadStore(); err == nil {
+					s.refreshTeammateRosters(name, refreshStore, refreshAssets)
+				}
+			}
+		}
 	}
 
 	// Persist which asset IDs were used so the card and dialog can show them.
@@ -195,15 +243,6 @@ func (s *Server) handleConfigureInstance(w http.ResponseWriter, r *http.Request)
 		if err := assetsStore.SaveAssets(); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
-		}
-	}
-
-	// Refresh teammates' SOUL.md so their roster includes this instance.
-	if req.CharacterAssetID != "" {
-		if refreshAssets, err := s.loadAssets(); err == nil {
-			if refreshStore, err := s.loadStore(); err == nil {
-				s.refreshTeammateRosters(name, refreshStore, refreshAssets)
-			}
 		}
 	}
 

--- a/internal/web/static/js/app.js
+++ b/internal/web/static/js/app.js
@@ -293,6 +293,7 @@ function App() {
           onSkills=${(name) => setSkillsName(name)}
           onHermesDashboard=${onHermesDashboard}
           onCreateClick=${() => setShowCreate(true)}
+          addToast=${addToast}
         />
       `;
       break;
@@ -312,6 +313,7 @@ function App() {
     ${configureName && html`
       <${ConfigureDialog}
         instanceName=${configureName}
+        runtimeType=${(instances.find(i => i.name === configureName) || {}).runtime_type || 'openclaw'}
         currentModelAssetId=${(instances.find(i => i.name === configureName) || {}).model_asset_id || ''}
         currentCharacterAssetId=${(instances.find(i => i.name === configureName) || {}).character_asset_id || ''}
         onClose=${() => setConfigureName(null)}

--- a/internal/web/static/js/components/configure-dialog.js
+++ b/internal/web/static/js/components/configure-dialog.js
@@ -2,7 +2,7 @@ import { html, useState, useEffect } from '../lib.js';
 import { useLang } from '../i18n.js';
 import { api } from '../api.js';
 
-export function ConfigureDialog({ instanceName, currentModelAssetId, currentCharacterAssetId, onClose, onConfigure }) {
+export function ConfigureDialog({ instanceName, runtimeType, currentModelAssetId, currentCharacterAssetId, onClose, onConfigure }) {
   const { t } = useLang();
   const [models, setModels] = useState([]);
   const [channels, setChannels] = useState([]);
@@ -37,20 +37,24 @@ export function ConfigureDialog({ instanceName, currentModelAssetId, currentChar
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!selectedModel) return;
+    if (!isHermes && !selectedModel) return;
 
     setConfiguring(true);
     await onConfigure(instanceName, {
-      model_asset_id: selectedModel,
+      model_asset_id: selectedModel || undefined,
       channel_asset_id: selectedChannel || undefined,
       character_asset_id: selectedCharacter || undefined,
     });
     setConfiguring(false);
   };
 
-  // Models are shared — show all validated models
-  const availableModels = models.filter(m => m.validated);
-  const availableChannels = channels.filter(c => c.validated && (!c.used_by || c.used_by === instanceName));
+  const isHermes = runtimeType === 'hermes';
+  // Models are shared — show all validated models.
+  // Hermes doesn't support openai-codex (requires interactive auth).
+  const availableModels = models.filter(m => m.validated && (!isHermes || m.provider !== 'openai-codex'));
+  // Hermes only supports discord, telegram, slack channels
+  const hermesChannels = ['discord', 'telegram', 'slack'];
+  const availableChannels = channels.filter(c => c.validated && (!c.used_by || c.used_by === instanceName) && (!isHermes || hermesChannels.includes(c.channel)));
 
   const providerLabel = (p) => {
     const map = { anthropic: 'Anthropic', openai: 'OpenAI', google: 'Google', deepseek: 'DeepSeek' };
@@ -89,6 +93,7 @@ export function ConfigureDialog({ instanceName, currentModelAssetId, currentChar
                 </div>
               `}
 
+              ${!isHermes && html`
               <div class="form-label" style="margin-top:16px">${t('configure.characterConfig')}</div>
               <div class="config-select-list">
                 <label class="config-select-item ${!selectedCharacter ? 'config-select-active' : ''}">
@@ -111,6 +116,7 @@ export function ConfigureDialog({ instanceName, currentModelAssetId, currentChar
                   </label>
                 `)}
               </div>
+              `}
 
               <div class="form-label" style="margin-top:16px">${t('configure.channelConfig')}</div>
               <div class="config-select-list">
@@ -139,7 +145,7 @@ export function ConfigureDialog({ instanceName, currentModelAssetId, currentChar
             <div class="dialog-footer">
               ${configuring && html`<span class="form-hint" style="margin-right:auto">${t('configure.timeHint')}</span>`}
               <button type="button" class="btn btn-ghost" onClick=${onClose} disabled=${configuring}>${t('configure.cancel')}</button>
-              <button type="submit" class="btn btn-primary" disabled=${configuring || !selectedModel}>
+              <button type="submit" class="btn btn-primary" disabled=${configuring || (!isHermes && !selectedModel)}>
                 ${configuring ? t('configure.configuring') : t('configure.submit')}
               </button>
             </div>

--- a/internal/web/static/js/components/dashboard.js
+++ b/internal/web/static/js/components/dashboard.js
@@ -13,7 +13,7 @@ function SkeletonCard() {
   `;
 }
 
-export function Dashboard({ instances, stats, loading, pending, selected, onToggleSelect, onSelectAll, onBatchDestroy, onStart, onStop, onDestroy, onDesktop, onConsole, onRestartBot, onConfigure, onSnapshot, onSkills, onHermesDashboard, onCreateClick }) {
+export function Dashboard({ instances, stats, loading, pending, selected, onToggleSelect, onSelectAll, onBatchDestroy, onStart, onStop, onDestroy, onDesktop, onConsole, onRestartBot, onConfigure, onSnapshot, onSkills, onHermesDashboard, onCreateClick, addToast }) {
   const { t } = useLang();
 
   if (loading) {
@@ -84,6 +84,7 @@ export function Dashboard({ instances, stats, loading, pending, selected, onTogg
               onSnapshot=${() => onSnapshot(inst.name)}
               onSkills=${() => onSkills(inst.name)}
               onHermesDashboard=${() => onHermesDashboard(inst.name)}
+              addToast=${addToast}
             />
           `;
           return html`

--- a/internal/web/static/js/components/instance-card.js
+++ b/internal/web/static/js/components/instance-card.js
@@ -2,8 +2,14 @@ import { html } from '../lib.js';
 import { useLang } from '../i18n.js';
 import { formatBytes } from '../utils.js';
 
-export function InstanceCard({ instance, stats, pending, selected, onToggleSelect, onStart, onStop, onDestroy, onDesktop, onConsole, onRestartBot, onConfigure, onSnapshot, onSkills, onHermesDashboard }) {
+export function InstanceCard({ instance, stats, pending, selected, onToggleSelect, onStart, onStop, onDestroy, onDesktop, onConsole, onRestartBot, onConfigure, onSnapshot, onSkills, onHermesDashboard, addToast }) {
   const { t } = useLang();
+  const copyShellCmd = () => {
+    navigator.clipboard.writeText(`clawfleet shell ${instance.name}`).then(
+      () => addToast && addToast(t('card.shellCopied', instance.name), 'success'),
+      () => {}
+    );
+  };
   const isRunning = instance.status === 'running';
   const isHermes = instance.runtime_type === 'hermes';
   const cpu = stats?.cpu_percent ?? 0;
@@ -123,7 +129,11 @@ export function InstanceCard({ instance, stats, pending, selected, onToggleSelec
           `}
           ${isHermes && html`
             <button class="btn btn-sm btn-desktop" onClick=${onHermesDashboard} disabled=${busy}>${t('card.hermesDashboard')}</button>
+            <button class="btn btn-sm btn-configure" onClick=${onConfigure} disabled=${busy}>
+              ${pending === 'configuring' ? t('action.configuring') : t('card.configure')}
+            </button>
           `}
+          ${isHermes && html`<button class="btn btn-sm btn-configure" onClick=${copyShellCmd}>${t('card.shell')}</button>`}
           <button class="btn btn-sm btn-warning" onClick=${onStop} disabled=${busy}>
             ${pending === 'stopping' ? t('action.stopping') : t('card.suspend')}
           </button>

--- a/internal/web/static/js/i18n.js
+++ b/internal/web/static/js/i18n.js
@@ -26,7 +26,9 @@ const messages = {
     'card.resume':           '▶ Resume',
     'card.destroy':          '🗑 Destroy',
     'card.unconfigured':     'Not configured',
-    'card.hermesUnconfigured': 'Configure in Dashboard →',
+    'card.hermesUnconfigured': 'Not configured',
+    'card.shell':            '📋 Shell',
+    'card.shellCopied':      (name) => `Copied: clawfleet shell ${name}`,
     'status.suspended':      'suspended',
 
     'create.title':          'Create Instances',
@@ -255,7 +257,9 @@ const messages = {
     'card.resume':           '▶ 复位',
     'card.destroy':          '🗑 销毁',
     'card.unconfigured':     '未配置',
-    'card.hermesUnconfigured': '在 Dashboard 中配置 →',
+    'card.hermesUnconfigured': '未配置',
+    'card.shell':            '📋 Shell',
+    'card.shellCopied':      (name) => `已复制: clawfleet shell ${name}`,
     'status.suspended':      '挂起中',
 
     'create.title':          '创建实例',


### PR DESCRIPTION
## Summary
- **Hermes Configure**: Dashboard Configure button now works for Hermes instances — inject model (OpenAI/Anthropic/Google/DeepSeek) + channel (Discord/Telegram/Slack) via API, with Codex auto-detection for channel-only mode
- **OpenClaw Discord fix**: Retry + offline policy writes to prevent hot-reload restart loop and token loss race condition  
- **Instance naming**: New instances use `openclaw-N` / `hermes-N` (backward compatible with existing `claw-N`)
- **CLAUDE.md**: Added "External Component Spec-First" and "Self-Test to Completion" engineering principles

## Test plan
- [x] Create fresh OpenClaw instance → Configure (API model + Discord channel) → DM bot → verify response
- [x] Create fresh Hermes instance → Configure (API model + Discord channel) → DM bot → verify response  
- [x] Create fresh Hermes instance → Codex login via native Dashboard → Configure (channel-only) → DM bot → verify response
- [x] Verify Codex model asset rejected for Hermes with clear error message
- [x] Verify instance naming: `openclaw-1`, `hermes-1`, `hermes-2`
- [x] Verify existing `claw-N` instances still work after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)