### PR TITLE
feat: default DeepSeek model preset to V4 Pro

### DIFF
--- a/internal/web/static/js/components/model-asset-dialog.js
+++ b/internal/web/static/js/components/model-asset-dialog.js
@@ -7,7 +7,7 @@ const MODEL_PRESETS = {
   openai: ['gpt-5.4', 'o3', 'gpt-5-mini'],
   'openai-codex': ['gpt-5.4', 'o3', 'gpt-5-mini'],
   google: ['gemini-3.1-pro-preview', 'gemini-3-flash-preview', 'gemini-2.5-pro'],
-  deepseek: ['deepseek-chat', 'deepseek-reasoner'],
+  deepseek: ['deepseek-v4-pro', 'deepseek-v4-flash', 'deepseek-chat', 'deepseek-reasoner'],
 };
 
 export function ModelAssetDialog({ model, onClose, onSave, addToast }) {
@@ -42,7 +42,7 @@ export function ModelAssetDialog({ model, onClose, onSave, addToast }) {
     openai: 'e.g. GPT-5.4 Production',
     'openai-codex': 'e.g. ChatGPT GPT-5.4',
     google: 'e.g. Google AI Studio Gemini',
-    deepseek: 'e.g. DeepSeek Chat',
+    deepseek: 'e.g. DeepSeek V4 Pro',
   };
 
   const handleProviderChange = (newProvider) => {


### PR DESCRIPTION
## Summary
- Move DeepSeek V4 family (`deepseek-v4-pro`, `deepseek-v4-flash`) to the front of the model dropdown so the dialog defaults to V4 Pro
- Keep legacy `deepseek-chat` / `deepseek-reasoner` as selectable options for users who have not migrated
- Update the DeepSeek name placeholder to "e.g. DeepSeek V4 Pro"

The validation path is unchanged: `GET https://api.deepseek.com/v1/models` only lists models, so the Test button remains effectively zero-token.

## Test plan
- [x] `make test`
- [x] `make build` and replace `~/.local/bin/clawfleet`, restart dashboard
- [x] `curl /js/components/model-asset-dialog.js` — confirms new preset is served
- [x] `curl POST /api/v1/assets/models/test` with bogus key — returns the expected `invalid API key (HTTP 401)` error
- [x] Real key end-to-end via the Dashboard — created a `deepseek-v4-flash` asset, Test passed, asset persisted with `validated=true`
- [ ] Wiki `Provider-DeepSeek.md` and `Dashboard-Guide.md` preset table updates (separate repo, follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)