### PR TITLE
fix: backfill runtime_type for legacy state entries

### DIFF
--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -148,6 +148,15 @@ func Status(cli *docker.Client, containerID string) (string, time.Time, error) {
 	}
 }
 
+// ImageOf returns the image reference (Config.Image) the container was created with.
+func ImageOf(cli *docker.Client, containerID string) (string, error) {
+	c, err := cli.InspectContainerWithOptions(docker.InspectContainerOptions{ID: containerID})
+	if err != nil {
+		return "", fmt.Errorf("inspecting container %s: %w", containerID, err)
+	}
+	return c.Config.Image, nil
+}
+
 func Logs(cli *docker.Client, containerID string, follow bool, out io.Writer) error {
 	return cli.Logs(docker.LogsOptions{
 		Container:    containerID,

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -135,6 +135,18 @@ func (s *Store) SetStatus(name, status string) {
 	}
 }
 
+// SetRuntimeType updates the runtime type of the named instance.
+func (s *Store) SetRuntimeType(name, runtimeType string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, inst := range s.instances {
+		if inst.Name == name {
+			inst.RuntimeType = runtimeType
+			return
+		}
+	}
+}
+
 // SetConfig stores the asset IDs used to configure the named instance.
 func (s *Store) SetConfig(name, modelAssetID, channelAssetID, characterAssetID string) {
 	s.mu.Lock()

--- a/internal/web/migrate.go
+++ b/internal/web/migrate.go
@@ -1,0 +1,69 @@
+package web
+
+import (
+	"log"
+	"strings"
+
+	"github.com/clawfleet/clawfleet/internal/container"
+	"github.com/clawfleet/clawfleet/internal/state"
+)
+
+// runtimeFromImage classifies a container's image reference into a runtime
+// type. Returns "hermes" if the ref contains the configured Hermes image
+// name, "openclaw" otherwise.
+func runtimeFromImage(imageRef, hermesImageName string) string {
+	if hermesImageName == "" || imageRef == "" {
+		return "openclaw"
+	}
+	if strings.Contains(strings.ToLower(imageRef), strings.ToLower(hermesImageName)) {
+		return "hermes"
+	}
+	return "openclaw"
+}
+
+// imageLookupFunc resolves a container's image ref. A non-nil error tells the
+// caller to skip that instance instead of misclassifying it.
+type imageLookupFunc func(containerID string) (string, error)
+
+// backfillRuntimeTypes fills in RuntimeType for instances whose state.json
+// entry is missing the field — a one-shot self-heal for records written by
+// older binaries that pre-date the field. Returns the number of records
+// updated.
+func backfillRuntimeTypes(store *state.Store, hermesImageName string, lookup imageLookupFunc) (int, error) {
+	fixed := 0
+	for _, inst := range store.Snapshot() {
+		if inst.RuntimeType != "" {
+			continue
+		}
+		imageRef, err := lookup(inst.ContainerID)
+		if err != nil {
+			log.Printf("backfill: skip %s: %v", inst.Name, err)
+			continue
+		}
+		store.SetRuntimeType(inst.Name, runtimeFromImage(imageRef, hermesImageName))
+		fixed++
+	}
+	if fixed == 0 {
+		return 0, nil
+	}
+	return fixed, store.Save()
+}
+
+// runMigrations runs one-shot data migrations at server startup. Failures are
+// logged but never block the server from starting.
+func (s *Server) runMigrations() {
+	store, err := s.loadStore()
+	if err != nil {
+		log.Printf("migrations: load store failed: %v", err)
+		return
+	}
+	n, err := backfillRuntimeTypes(store, s.config.Hermes.ImageName, func(cid string) (string, error) {
+		return container.ImageOf(s.docker, cid)
+	})
+	if err != nil {
+		log.Printf("migrations: backfill runtime_type save failed: %v", err)
+	}
+	if n > 0 {
+		log.Printf("migrations: backfilled runtime_type for %d instance(s)", n)
+	}
+}

--- a/internal/web/migrate_test.go
+++ b/internal/web/migrate_test.go
@@ -1,0 +1,141 @@
+package web
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/clawfleet/clawfleet/internal/state"
+)
+
+func TestRuntimeFromImage(t *testing.T) {
+	const hermesName = "nousresearch/hermes-agent"
+
+	tests := []struct {
+		desc, imageRef, hermesName, want string
+	}{
+		{"hermes by exact ref", "nousresearch/hermes-agent:latest", hermesName, "hermes"},
+		{"hermes case-insensitive", "Nousresearch/Hermes-Agent:1.0", hermesName, "hermes"},
+		{"hermes with registry prefix", "docker.io/nousresearch/hermes-agent:dev", hermesName, "hermes"},
+		{"openclaw image", "ghcr.io/clawfleet/clawfleet:latest", hermesName, "openclaw"},
+		{"unrelated image", "alpine:3.20", hermesName, "openclaw"},
+		{"empty hermes name → openclaw", "anything", "", "openclaw"},
+		{"empty image → openclaw", "", hermesName, "openclaw"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := runtimeFromImage(tt.imageRef, tt.hermesName); got != tt.want {
+				t.Fatalf("runtimeFromImage(%q,%q) = %q, want %q", tt.imageRef, tt.hermesName, got, tt.want)
+			}
+		})
+	}
+}
+
+// seedStore writes the given state.json into a fake home dir and returns a
+// loaded Store rooted there.
+func seedStore(t *testing.T, contents string) *state.Store {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".clawfleet")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(contents), 0o644); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	store, err := state.Load()
+	if err != nil {
+		t.Fatalf("load store: %v", err)
+	}
+	return store
+}
+
+func TestBackfillRuntimeTypes_FillsMissing(t *testing.T) {
+	store := seedStore(t, `{"instances":[
+		{"name":"hermes-1","container_id":"cid-h","status":"running","ports":{"novnc":1,"gateway":2},"created_at":"2026-04-23T21:39:03Z"},
+		{"name":"openclaw-1","container_id":"cid-o","status":"running","ports":{"novnc":3,"gateway":4},"created_at":"2026-04-23T21:38:56Z"}
+	]}`)
+
+	lookup := func(cid string) (string, error) {
+		switch cid {
+		case "cid-h":
+			return "nousresearch/hermes-agent:latest", nil
+		case "cid-o":
+			return "ghcr.io/clawfleet/clawfleet:latest", nil
+		}
+		return "", errors.New("unknown container")
+	}
+
+	n, err := backfillRuntimeTypes(store, "nousresearch/hermes-agent", lookup)
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("fixed = %d, want 2", n)
+	}
+	if got := store.Get("hermes-1").RuntimeType; got != "hermes" {
+		t.Fatalf("hermes-1 runtime = %q, want hermes", got)
+	}
+	if got := store.Get("openclaw-1").RuntimeType; got != "openclaw" {
+		t.Fatalf("openclaw-1 runtime = %q, want openclaw", got)
+	}
+
+	// Reload from disk to verify persistence.
+	reloaded, err := state.Load()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got := reloaded.Get("hermes-1").RuntimeType; got != "hermes" {
+		t.Fatalf("persisted hermes-1 runtime = %q, want hermes", got)
+	}
+}
+
+func TestBackfillRuntimeTypes_LeavesPopulatedAlone(t *testing.T) {
+	store := seedStore(t, `{"instances":[
+		{"name":"already","container_id":"cid","status":"running","ports":{"novnc":1,"gateway":2},"created_at":"2026-04-23T21:39:03Z","runtime_type":"hermes"}
+	]}`)
+
+	called := false
+	lookup := func(string) (string, error) {
+		called = true
+		return "", nil
+	}
+
+	n, err := backfillRuntimeTypes(store, "nousresearch/hermes-agent", lookup)
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("fixed = %d, want 0", n)
+	}
+	if called {
+		t.Fatal("lookup invoked for instance that already had runtime_type")
+	}
+	if got := store.Get("already").RuntimeType; got != "hermes" {
+		t.Fatalf("runtime mutated: %q", got)
+	}
+}
+
+func TestBackfillRuntimeTypes_SkipsLookupErrors(t *testing.T) {
+	store := seedStore(t, `{"instances":[
+		{"name":"missing","container_id":"gone","status":"running","ports":{"novnc":1,"gateway":2},"created_at":"2026-04-23T21:39:03Z"}
+	]}`)
+
+	lookup := func(string) (string, error) {
+		return "", errors.New("no such container")
+	}
+
+	n, err := backfillRuntimeTypes(store, "nousresearch/hermes-agent", lookup)
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("fixed = %d, want 0", n)
+	}
+	if got := store.Get("missing").RuntimeType; got != "" {
+		t.Fatalf("runtime should remain empty, got %q", got)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -48,6 +48,8 @@ func (s *Server) loadStore() (*state.Store, error) {
 
 // ListenAndServe starts the HTTP server and blocks until interrupted.
 func (s *Server) ListenAndServe() error {
+	s.runMigrations()
+
 	mux := http.NewServeMux()
 	s.registerRoutes(mux)
 


### PR DESCRIPTION
## Summary
Instances created by binaries that pre-date the `RuntimeType` field have no `runtime_type` in `state.json`. The list handler then falls back to `"openclaw"` (`internal/web/handlers.go:39-43`), so Hermes containers get reported as OpenClaw and the dashboard's runtime grouping collapses into a single mixed grid.

This change adds a one-shot self-heal at dashboard startup:

- `container.ImageOf(cli, containerID)` exposes a container's image ref
- `state.Store.SetRuntimeType(name, rt)` lets callers patch the field
- `web.runtimeFromImage(imageRef, hermesImageName)` classifies the runtime by checking whether the image ref contains the configured Hermes image name (case-insensitive)
- `web.backfillRuntimeTypes` walks the store, looks up the image of each instance missing `runtime_type`, classifies, and saves once
- `Server.runMigrations` runs the backfill at startup; lookup failures are skipped, store-load failures are logged but don't block the server

The fix is idempotent — instances that already have `runtime_type` are skipped without any docker call.

## Test plan
- [x] `go test ./internal/web/...` — new unit tests cover `runtimeFromImage` cases plus three `backfillRuntimeTypes` flows (fills missing, leaves populated alone, skips inspect errors)
- [x] `make test` — all packages green
- [x] Real environment: started dashboard against state.json with three records missing `runtime_type` — log printed `migrations: backfilled runtime_type for 3 instance(s)`, `state.json` now shows `hermes-1/2 → "hermes"`, `openclaw-1 → "openclaw"`, `GET /api/v1/instances` returns the correct runtimes
- [x] Restarted again — no `backfilled` log line emitted (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)